### PR TITLE
Fix: Back navigation in venue list

### DIFF
--- a/.idea/AndroidProjectSystem.xml
+++ b/.idea/AndroidProjectSystem.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="AndroidProjectSystem">
+    <option name="providerId" value="com.android.tools.idea.GradleProjectSystem" />
+  </component>
+</project>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="ExternalStorageConfigurationManager" enabled="true" />
   <component name="ProjectRootManager" version="2" languageLevel="JDK_17" default="true" project-jdk-name="corretto-17" project-jdk-type="JavaSDK">

--- a/app/src/main/java/com/example/sporthub/ui/MainActivity.kt
+++ b/app/src/main/java/com/example/sporthub/ui/MainActivity.kt
@@ -35,6 +35,7 @@ import com.example.sporthub.ui.bookings.BookingsFragment
 import com.example.sporthub.ui.createBooking.CreateBookingFragment
 import com.example.sporthub.ui.findVenues.FindVenuesFragment
 import com.example.sporthub.ui.profile.ProfileFragment
+import com.google.android.material.appbar.MaterialToolbar
 
 
 class MainActivity : AppCompatActivity() {
@@ -100,6 +101,36 @@ class MainActivity : AppCompatActivity() {
         val navHostFragment =
             supportFragmentManager.findFragmentById(R.id.nav_host_fragment) as NavHostFragment
         val navController = navHostFragment.navController
+
+        // Set up ActionBar with NavController
+
+        val toolbar: MaterialToolbar = findViewById(R.id.topAppBar)
+        setSupportActionBar(toolbar)
+
+        val appBarConfiguration = AppBarConfiguration(
+            setOf(
+                R.id.navigation_home,
+                R.id.findVenuesFragment,
+                R.id.navigation_profile,
+                R.id.navigation_booking,
+                R.id.navigation_create
+            )
+        )
+        setupActionBarWithNavController(navController, appBarConfiguration)
+
+        navController.addOnDestinationChangedListener { _, destination, _ ->
+            val titleView: TextView? = findViewById(R.id.toolbarTitle)
+            titleView?.text = when (destination.id) {
+                R.id.findVenuesFragment -> "Find Venues"
+                R.id.venueListFragment -> "Venue List"
+                R.id.navigation_home -> "SportHub"
+                R.id.navigation_profile -> "Profile"
+                R.id.navigation_booking -> "Bookings"
+                R.id.navigation_create -> "Create Booking"
+                else -> "SportHub"
+            }
+        }
+
 
         // Set up Bottom Navigation with NavController
         val bottomNavigationView: BottomNavigationView = findViewById(R.id.nav_view)

--- a/app/src/main/java/com/example/sporthub/ui/venueList/VenueListFragment.kt
+++ b/app/src/main/java/com/example/sporthub/ui/venueList/VenueListFragment.kt
@@ -5,12 +5,15 @@ import android.content.pm.PackageManager
 import android.location.Location
 import android.os.Bundle
 import android.view.LayoutInflater
+import android.view.MenuItem
 import android.view.View
 import android.view.ViewGroup
+import androidx.appcompat.app.AppCompatActivity
 import androidx.core.app.ActivityCompat
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.Observer
+import androidx.navigation.fragment.findNavController
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import com.example.sporthub.R
@@ -27,6 +30,11 @@ class VenueListFragment : Fragment() {
     private lateinit var fusedLocationClient: FusedLocationProviderClient
     private var userLocation: Location? = null
 
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setHasOptionsMenu(true)
+    }
+
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
         savedInstanceState: Bundle?
@@ -36,6 +44,8 @@ class VenueListFragment : Fragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+
+        (requireActivity() as AppCompatActivity).supportActionBar?.setDisplayHomeAsUpEnabled(true)
 
         val sportId = arguments?.getString("sportId") ?: return
 
@@ -56,6 +66,16 @@ class VenueListFragment : Fragment() {
                 venueAdapter.submitList(sortedVenues)
             })
             viewModel.fetchVenuesBySport(sportId)
+        }
+    }
+
+    override fun onOptionsItemSelected(item: MenuItem): Boolean {
+        return when (item.itemId) {
+            android.R.id.home -> {
+                findNavController().navigateUp()
+                true
+            }
+            else -> super.onOptionsItemSelected(item)
         }
     }
 
@@ -83,4 +103,6 @@ class VenueListFragment : Fragment() {
             currentLocation.distanceTo(venueLocation)
         }
     }
+
+
 }

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -40,4 +40,28 @@
         app:layout_constraintLeft_toLeftOf="parent"
         app:layout_constraintRight_toRightOf="parent"/>
 
+    <com.google.android.material.appbar.MaterialToolbar
+        android:id="@+id/topAppBar"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:background="#FFFFFF"
+        android:elevation="4dp"
+        app:layout_constraintTop_toTopOf="parent">
+        <TextView
+            android:id="@+id/toolbarTitle"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:gravity="center"
+            android:text="SportHub"
+            android:layout_marginEnd="?android:attr/actionBarSize"
+            android:textColor="#070304"
+            android:textSize="20sp"
+            android:textStyle="bold"
+            android:paddingVertical="16dp"
+            android:paddingHorizontal="32dp" />
+    </com.google.android.material.appbar.MaterialToolbar>
+
+
+
+
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/fragment_venue_list.xml
+++ b/app/src/main/res/layout/fragment_venue_list.xml
@@ -11,7 +11,6 @@
         android:layout_height="wrap_content"
         android:background="@android:color/white"
         android:padding="16dp"
-        android:elevation="4dp"
         android:orientation="vertical">
 
         <TextView


### PR DESCRIPTION
This commit modified files `MainActivity.kt`, `activity_main.xml`, `fragment_venue_list.xml `and `VenueListFragment.kt` in order to add a Toolbar to the application.
![image](https://github.com/user-attachments/assets/3c4d2457-8792-46d3-8f1c-58a6d1fc3669)

Although it looks exactly the same as before, it's now officially a toolbar, and not a linear layout with text and elevation. By being a toolbar, it allowed back navigation from different views, in this case, the back button was only made available for the Venue List view.
![image](https://github.com/user-attachments/assets/d04486ba-ea97-48b2-b0f5-a10e145e7df9)

Now, in order to go back from the Venue List view to the Find Venues view, the user has the chance to either use the back button or the device's back button, both have the same effect.

Might be useful to remark that the user can't go back to Find Venues view by pressing the corresponding icon in the navbar, doing so will return the user to the last state that view was in, be it the Find Venues or the Venue List. 