### PR TITLE
Fix/28 login back navigation

### DIFF
--- a/app/src/main/java/com/example/sporthub/ui/login/BirthDateSelectionActivity.kt
+++ b/app/src/main/java/com/example/sporthub/ui/login/BirthDateSelectionActivity.kt
@@ -104,8 +104,10 @@ class BirthDateSelectionActivity : AppCompatActivity() {
             calendar.get(Calendar.DAY_OF_MONTH)
         )
 
-        // Limitar la fecha máxima a la fecha actual
-        datePickerDialog.datePicker.maxDate = System.currentTimeMillis()
+        // Establecer fecha máxima (Requerimiento de edad - Los usuarios deben tener, por lo menos, 14)
+        val maxDate = Calendar.getInstance()
+        maxDate.add(Calendar.YEAR, -14)
+        datePickerDialog.datePicker.maxDate = maxDate.timeInMillis
 
         // Establecer fecha mínima (por ejemplo, 100 años atrás)
         val minDate = Calendar.getInstance()

--- a/app/src/main/java/com/example/sporthub/ui/login/BirthDateSelectionActivity.kt
+++ b/app/src/main/java/com/example/sporthub/ui/login/BirthDateSelectionActivity.kt
@@ -5,6 +5,7 @@ import android.content.Intent
 import android.os.Bundle
 import android.widget.Button
 import android.widget.EditText
+import android.widget.ImageButton
 import android.widget.Toast
 import androidx.activity.OnBackPressedCallback
 import androidx.appcompat.app.AppCompatActivity
@@ -46,6 +47,12 @@ class BirthDateSelectionActivity : AppCompatActivity() {
                 finish()
             }
         })
+
+        // Manejar botón de retroceso nuevo
+        val backButton = findViewById<ImageButton>(R.id.button_back_birth)
+        backButton.setOnClickListener {
+            finish()
+        }
 
         // Inicializar vistas
         datePickerEditText = findViewById(R.id.date_picker_edit_text)

--- a/app/src/main/java/com/example/sporthub/ui/login/BirthDateSelectionActivity.kt
+++ b/app/src/main/java/com/example/sporthub/ui/login/BirthDateSelectionActivity.kt
@@ -40,9 +40,10 @@ class BirthDateSelectionActivity : AppCompatActivity() {
             override fun handleOnBackPressed() {
                 Toast.makeText(
                     this@BirthDateSelectionActivity,
-                    "Please select your birth date to continue",
+                    "Going back to gender selection!",
                     Toast.LENGTH_SHORT
                 ).show()
+                finish()
             }
         })
 
@@ -140,7 +141,6 @@ class BirthDateSelectionActivity : AppCompatActivity() {
     private fun navigateToSportsSelection() {
         val intent = Intent(this, FavoriteSportsSelectionActivity::class.java)
         startActivity(intent)
-        finish()
     }
 
     private fun redirectToSignIn() {

--- a/app/src/main/java/com/example/sporthub/ui/login/FavoriteSportsSelectionActivity.kt
+++ b/app/src/main/java/com/example/sporthub/ui/login/FavoriteSportsSelectionActivity.kt
@@ -61,9 +61,10 @@ class FavoriteSportsSelectionActivity : AppCompatActivity() {
             override fun handleOnBackPressed() {
                 Toast.makeText(
                     this@FavoriteSportsSelectionActivity,
-                    "Please select at least one sport to continue",
+                    "Going back to birthdate selector!",
                     Toast.LENGTH_SHORT
                 ).show()
+                finish()
             }
         })
 

--- a/app/src/main/java/com/example/sporthub/ui/login/FavoriteSportsSelectionActivity.kt
+++ b/app/src/main/java/com/example/sporthub/ui/login/FavoriteSportsSelectionActivity.kt
@@ -10,6 +10,7 @@ import androidx.appcompat.app.AppCompatActivity
 import androidx.cardview.widget.CardView
 import androidx.lifecycle.ViewModelProvider
 import android.graphics.Color
+import android.widget.ImageButton
 import com.example.sporthub.R
 import com.example.sporthub.ui.MainActivity
 import com.example.sporthub.viewmodel.SportSelectionViewModel
@@ -67,6 +68,12 @@ class FavoriteSportsSelectionActivity : AppCompatActivity() {
                 finish()
             }
         })
+
+        // Manejar botón de retroceso nuevo
+        val backButton = findViewById<ImageButton>(R.id.button_back_sport)
+        backButton.setOnClickListener {
+            finish()
+        }
 
         try {
             // Configurar listeners para las tarjetas de deportes

--- a/app/src/main/java/com/example/sporthub/ui/login/GenderSelectionActivity.kt
+++ b/app/src/main/java/com/example/sporthub/ui/login/GenderSelectionActivity.kt
@@ -37,9 +37,10 @@ class GenderSelectionActivity : AppCompatActivity() {
             override fun handleOnBackPressed() {
                 Toast.makeText(
                     this@GenderSelectionActivity,
-                    "Please select your gender to continue",
+                    "Going back to name selection!",
                     Toast.LENGTH_SHORT
                 ).show()
+                finish()
             }
         })
 
@@ -88,7 +89,6 @@ class GenderSelectionActivity : AppCompatActivity() {
     private fun navigateToBirthDateSelection() {
         val intent = Intent(this, BirthDateSelectionActivity::class.java)
         startActivity(intent)
-        finish()
     }
 
     private fun redirectToSignIn() {
@@ -96,4 +96,5 @@ class GenderSelectionActivity : AppCompatActivity() {
         startActivity(intent)
         finish()
     }
+
 }

--- a/app/src/main/java/com/example/sporthub/ui/login/GenderSelectionActivity.kt
+++ b/app/src/main/java/com/example/sporthub/ui/login/GenderSelectionActivity.kt
@@ -3,6 +3,7 @@ package com.example.sporthub.ui.login
 import android.content.Intent
 import android.os.Bundle
 import android.util.Log
+import android.widget.ImageButton
 import android.widget.Toast
 import androidx.activity.OnBackPressedCallback
 import androidx.appcompat.app.AppCompatActivity
@@ -32,7 +33,7 @@ class GenderSelectionActivity : AppCompatActivity() {
         // Configurar observadores para eventos del ViewModel
         setupObservers()
 
-        // Manejar botón de retroceso
+        // Manejar botón de retroceso del dispositivo
         onBackPressedDispatcher.addCallback(this, object : OnBackPressedCallback(true) {
             override fun handleOnBackPressed() {
                 Toast.makeText(
@@ -43,6 +44,12 @@ class GenderSelectionActivity : AppCompatActivity() {
                 finish()
             }
         })
+
+        // Manejar botón de retroceso nuevo
+        val backButton = findViewById<ImageButton>(R.id.button_back_gender)
+        backButton.setOnClickListener {
+            finish()
+        }
 
         try {
             // Configurar listeners para los botones

--- a/app/src/main/java/com/example/sporthub/ui/login/NameSelectionActivity.kt
+++ b/app/src/main/java/com/example/sporthub/ui/login/NameSelectionActivity.kt
@@ -127,7 +127,6 @@ class NameSelectionActivity : AppCompatActivity() {
     private fun navigateToGenderSelection() {
         val intent = Intent(this, GenderSelectionActivity::class.java)
         startActivity(intent)
-        finish()
     }
 
     private fun redirectToSignIn() {

--- a/app/src/main/java/com/example/sporthub/ui/profile/ProfileFragment.kt
+++ b/app/src/main/java/com/example/sporthub/ui/profile/ProfileFragment.kt
@@ -1,31 +1,53 @@
 package com.example.sporthub.ui.profile
 
-import androidx.fragment.app.viewModels
+import android.content.Intent
 import android.os.Bundle
-import androidx.fragment.app.Fragment
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.Button
+import androidx.fragment.app.Fragment
 import com.example.sporthub.R
+import com.example.sporthub.ui.login.SignInActivity
+import com.google.android.gms.auth.api.signin.GoogleSignIn
+import com.google.android.gms.auth.api.signin.GoogleSignInOptions
+import com.google.firebase.auth.FirebaseAuth
 
 class ProfileFragment : Fragment() {
-
-    companion object {
-        fun newInstance() = ProfileFragment()
-    }
-
-    private val viewModel: ProfileViewModel by viewModels()
-
-    override fun onCreate(savedInstanceState: Bundle?) {
-        super.onCreate(savedInstanceState)
-
-        // TODO: Use the ViewModel
-    }
 
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View {
+        // Inflate the layout for this fragment
         return inflater.inflate(R.layout.fragment_profile, container, false)
     }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        val logoutButton = view.findViewById<Button>(R.id.button_logout)
+        logoutButton.setOnClickListener {
+            signOutAndStartSignInActivity()
+        }
+    }
+
+    private fun signOutAndStartSignInActivity() {
+        try {
+            val mAuth = FirebaseAuth.getInstance()
+            val gso = GoogleSignInOptions.Builder(GoogleSignInOptions.DEFAULT_SIGN_IN).build()
+            val mGoogleSignInClient = GoogleSignIn.getClient(requireActivity(), gso)
+
+            mAuth.signOut()
+
+            mGoogleSignInClient.signOut().addOnCompleteListener(requireActivity()) {
+                val intent = Intent(requireActivity(), SignInActivity::class.java)
+                intent.flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
+                startActivity(intent)
+            }
+        } catch (e: Exception) {
+            android.util.Log.e("ProfileFragment", "Error signing out: ${e.message}")
+        }
+    }
 }
+

--- a/app/src/main/res/drawable/ic_arrow_back.xml
+++ b/app/src/main/res/drawable/ic_arrow_back.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:fillColor="#FF000000"
+      android:pathData="M20,11H7.83l5.59,-5.59L12,4l-8,8 8,8 1.41,-1.41L7.83,13H20v-2z"/>
+</vector>

--- a/app/src/main/res/layout/activity_sign_in_birth_date_selection.xml
+++ b/app/src/main/res/layout/activity_sign_in_birth_date_selection.xml
@@ -15,6 +15,18 @@
         android:orientation="horizontal"
         app:layout_constraintGuide_percent="0.2" />
 
+    <ImageButton
+        android:id="@+id/button_back_birth"
+        android:layout_width="40dp"
+        android:layout_height="40dp"
+        android:background="@null"
+        android:src="@drawable/ic_arrow_back"
+        android:layout_marginStart="16dp"
+        android:layout_marginTop="16dp"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:tint="#673AB7"/>
+
     <TextView
         android:id="@+id/textview_title"
         android:layout_width="0dp"

--- a/app/src/main/res/layout/activity_sign_in_favorite_sports_selection.xml
+++ b/app/src/main/res/layout/activity_sign_in_favorite_sports_selection.xml
@@ -15,6 +15,18 @@
         android:orientation="horizontal"
         app:layout_constraintGuide_percent="0.15" />
 
+    <ImageButton
+        android:id="@+id/button_back_sport"
+        android:layout_width="40dp"
+        android:layout_height="40dp"
+        android:background="@null"
+        android:src="@drawable/ic_arrow_back"
+        android:layout_marginStart="16dp"
+        android:layout_marginTop="16dp"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:tint="#673AB7"/>
+
     <TextView
         android:id="@+id/textview_title"
         android:layout_width="0dp"

--- a/app/src/main/res/layout/activity_sign_in_gender_selection.xml
+++ b/app/src/main/res/layout/activity_sign_in_gender_selection.xml
@@ -15,6 +15,18 @@
         android:orientation="horizontal"
         app:layout_constraintGuide_percent="0.15" />
 
+    <ImageButton
+        android:id="@+id/button_back_gender"
+        android:layout_width="40dp"
+        android:layout_height="40dp"
+        android:background="@null"
+        android:src="@drawable/ic_arrow_back"
+        android:layout_marginStart="16dp"
+        android:layout_marginTop="16dp"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:tint="#673AB7"/>
+
     <TextView
         android:id="@+id/textview_title"
         android:layout_width="0dp"

--- a/app/src/main/res/layout/fragment_profile.xml
+++ b/app/src/main/res/layout/fragment_profile.xml
@@ -1,15 +1,30 @@
-<?xml version="1.0" encoding="utf-8"?>
 <FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     tools:context=".ui.profile.ProfileFragment">
 
-    <TextView
+    <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:text="This is the Profile Fragment" />
+        android:orientation="vertical"
+        android:gravity="center"
+        android:padding="24dp">
 
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="This is the Profile Fragment"
+            android:textSize="18sp"
+            android:textStyle="bold"
+            android:paddingBottom="16dp" />
 
-
+        <Button
+            android:id="@+id/button_logout"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="Logout"
+            android:backgroundTint="@color/purple_500"
+            android:textColor="@android:color/white" />
+    </LinearLayout>
 </FrameLayout>


### PR DESCRIPTION
During this fix, three main issues related to the "set preferences" process were addressed. The fixes include:

- **Enabled back navigation within the views:** Users can now navigate back if they realize one of the preferences they entered was incorrect. This can be done by tapping the arrow in the top-left corner or using the system’s native back gesture or button.

![image](https://github.com/user-attachments/assets/028acfb4-451a-45f2-8785-70e9dc777afd)


- **Restricted maximum birthdate:** To prevent users from entering invalid birthdates (e.g., setting it to a day before the current date), a minimum age restriction has been enforced. Users must now be at least 14 years old to register.

![image](https://github.com/user-attachments/assets/0d72d7f6-e21a-49e1-9552-17be2cb5fc25)


- **Added a logout button in the profile view:** This provides users with a clear and accessible way to log out of the application directly from their profile.

![image](https://github.com/user-attachments/assets/32cc024f-40cb-4960-98d3-112e68863d3d)
