### PR TITLE
Feat/40 eventual connectivity home view

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -89,4 +89,7 @@ dependencies {
     testImplementation("junit:junit:4.13.2")
     androidTestImplementation("androidx.test.ext:junit:1.1.5")
     androidTestImplementation("androidx.test.espresso:espresso-core:3.5.1")
+
+    // Para caching
+    implementation("com.google.code.gson:gson:2.10.1")
 }

--- a/app/src/main/java/com/example/sporthub/ui/home/HomeFragment.kt
+++ b/app/src/main/java/com/example/sporthub/ui/home/HomeFragment.kt
@@ -119,7 +119,12 @@ class HomeFragment : Fragment() {
         }
 
         homeViewModel.recommendedBookings.observe(viewLifecycleOwner) { bookings ->
-            recommendedBookingsAdapter.submitList(bookings)
+            // Si estamos offline, no mostramos bookings recomendados
+            if (homeViewModel.isOffline.value == true) {
+                recommendedBookingsAdapter.submitList(emptyList())
+            } else {
+                recommendedBookingsAdapter.submitList(bookings)
+            }
         }
 
         homeViewModel.isOffline.observe(viewLifecycleOwner) { offline ->

--- a/app/src/main/java/com/example/sporthub/ui/home/HomeFragment.kt
+++ b/app/src/main/java/com/example/sporthub/ui/home/HomeFragment.kt
@@ -69,7 +69,7 @@ class HomeFragment : Fragment() {
     private fun observeViewModels() {
         userViewModel.currentUser.observe(viewLifecycleOwner) { user ->
             if (user != null) {
-                homeViewModel.loadData(user)
+                homeViewModel.loadHomeData(requireContext(), user)
             }
         }
 
@@ -121,6 +121,12 @@ class HomeFragment : Fragment() {
         homeViewModel.recommendedBookings.observe(viewLifecycleOwner) { bookings ->
             recommendedBookingsAdapter.submitList(bookings)
         }
+
+        homeViewModel.isOffline.observe(viewLifecycleOwner) { offline ->
+            binding.textRecommendedOfflineWarning.visibility =
+                if (offline) View.VISIBLE else View.GONE
+        }
+
     }
 
     override fun onDestroyView() {

--- a/app/src/main/java/com/example/sporthub/ui/home/HomeFragment.kt
+++ b/app/src/main/java/com/example/sporthub/ui/home/HomeFragment.kt
@@ -1,12 +1,14 @@
 package com.example.sporthub.ui.home
 
+import android.content.BroadcastReceiver
+import android.content.IntentFilter
+import android.net.ConnectivityManager
 import android.os.Bundle
 import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.Fragment
-import androidx.fragment.app.viewModels
 import androidx.fragment.app.activityViewModels
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.example.sporthub.data.repository.HomeRepository
@@ -25,6 +27,8 @@ class HomeFragment : Fragment() {
     private lateinit var popularityAdapter: PopularityAdapter
     private lateinit var upcomingBookingsAdapter: UpcomingBookingsAdapter
     private lateinit var recommendedBookingsAdapter: RecommendedBookingsAdapter
+
+    private var networkReceiver: BroadcastReceiver? = null
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -137,5 +141,25 @@ class HomeFragment : Fragment() {
     override fun onDestroyView() {
         super.onDestroyView()
         _binding = null
+    }
+
+    override fun onStart() {
+        super.onStart()
+        networkReceiver = NetworkReceiver {
+            val user = userViewModel.currentUser.value
+            user?.let {
+                homeViewModel.loadHomeData(requireContext(), it)
+            }
+        }
+        val filter = IntentFilter(ConnectivityManager.CONNECTIVITY_ACTION)
+        requireContext().registerReceiver(networkReceiver, filter)
+    }
+
+
+    override fun onStop() {
+        super.onStop()
+        networkReceiver?.let {
+            requireContext().unregisterReceiver(it)
+        }
     }
 }

--- a/app/src/main/java/com/example/sporthub/ui/home/NetworkReciever.kt
+++ b/app/src/main/java/com/example/sporthub/ui/home/NetworkReciever.kt
@@ -1,0 +1,16 @@
+package com.example.sporthub.ui.home
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import com.example.sporthub.utils.ConnectivityHelper
+
+class NetworkReceiver(private val onReconnect: () -> Unit) : BroadcastReceiver() {
+    override fun onReceive(context: Context?, intent: Intent?) {
+        context?.let {
+            if (ConnectivityHelper.isNetworkAvailable(it)) {
+                onReconnect()
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/example/sporthub/utils/ConnectivityHelper.kt
+++ b/app/src/main/java/com/example/sporthub/utils/ConnectivityHelper.kt
@@ -1,0 +1,23 @@
+package com.example.sporthub.utils
+
+import android.content.Context
+import android.net.ConnectivityManager
+import android.net.NetworkCapabilities
+import android.os.Build
+
+object ConnectivityHelper {
+    @JvmStatic
+    fun isNetworkAvailable(context: Context): Boolean {
+        val connectivityManager = context.getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
+        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+            val network = connectivityManager.activeNetwork ?: return false
+            val capabilities = connectivityManager.getNetworkCapabilities(network) ?: return false
+            capabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET)
+        } else {
+            @Suppress("DEPRECATION")
+            val networkInfo = connectivityManager.activeNetworkInfo ?: return false
+            @Suppress("DEPRECATION")
+            networkInfo.isConnected
+        }
+    }
+}

--- a/app/src/main/java/com/example/sporthub/viewmodel/HomeViewModel.kt
+++ b/app/src/main/java/com/example/sporthub/viewmodel/HomeViewModel.kt
@@ -51,7 +51,7 @@ class HomeViewModel(private val repository: HomeRepository) : ViewModel() {
                     _upcomingBookings.value = upcoming
                     _popularityReport.value = mapReport(report, user)
 
-                    // Guardar en caché
+                    // Save in caché
                     with(prefs.edit()) {
                         putString("recommended", Gson().toJson(recommended))
                         putString("upcoming", Gson().toJson(upcoming))

--- a/app/src/main/java/com/example/sporthub/viewmodel/HomeViewModel.kt
+++ b/app/src/main/java/com/example/sporthub/viewmodel/HomeViewModel.kt
@@ -1,5 +1,6 @@
 package com.example.sporthub.viewmodel
 
+import android.content.Context
 import android.util.Log
 import androidx.lifecycle.*
 import com.example.sporthub.data.model.Booking
@@ -7,6 +8,9 @@ import com.example.sporthub.data.model.Sport
 import com.example.sporthub.data.model.User
 import com.example.sporthub.data.model.Venue
 import com.example.sporthub.data.repository.HomeRepository
+import com.example.sporthub.utils.ConnectivityHelper
+import com.google.gson.Gson
+import com.google.gson.reflect.TypeToken
 import kotlinx.coroutines.launch
 
 class HomeViewModel(private val repository: HomeRepository) : ViewModel() {
@@ -17,7 +21,6 @@ class HomeViewModel(private val repository: HomeRepository) : ViewModel() {
     private val _upcomingBookings = MutableLiveData<List<Booking>>()
     val upcomingBookings: LiveData<List<Booking>> = _upcomingBookings
 
-    // Update the data structure to include sport play count
     data class PopularityReportData(
         val highestRatedVenue: Venue?,
         val mostPlayedSport: Sport,
@@ -29,44 +32,75 @@ class HomeViewModel(private val repository: HomeRepository) : ViewModel() {
     private val _popularityReport = MutableLiveData<PopularityReportData>()
     val popularityReport: LiveData<PopularityReportData> = _popularityReport
 
-    fun loadData(user: User) {
+    private val _isOffline = MutableLiveData<Boolean>()
+    val isOffline: LiveData<Boolean> = _isOffline
+
+
+    fun loadHomeData(context: Context, user: User) {
         viewModelScope.launch {
-            try {
-                _recommendedBookings.value = repository.getRecommendedBookings(user)
-                _upcomingBookings.value = repository.getUpcomingBookings(user)
+            val prefs = context.getSharedPreferences("home_cache", Context.MODE_PRIVATE)
+            _isOffline.value = !ConnectivityHelper.isNetworkAvailable(context)
 
-                val report = repository.popularityReport(user)
+            if (ConnectivityHelper.isNetworkAvailable(context)) {
+                try {
+                    val recommended = repository.getRecommendedBookings(user)
+                    val upcoming = repository.getUpcomingBookings(user)
+                    val report = repository.popularityReport(user)
 
-                val highestRatedVenue = report["highestRatedVenue"] as? Venue
-                val mostBookedVenue = report["mostBookedVenue"] as? Venue
-                val mostPlayedSport = report["mostPlayedSport"] as? Sport
+                    _recommendedBookings.value = recommended
+                    _upcomingBookings.value = upcoming
+                    _popularityReport.value = mapReport(report, user)
 
-                // Get the most booked venue with count
-                val mostBookedVenueWithCount = report["mostBookedVenueWithCount"] as? HomeRepository.VenueWithBookingCount
-                val mostBookedCount = mostBookedVenueWithCount?.bookingCount ?: 0
+                    // Guardar en caché
+                    with(prefs.edit()) {
+                        putString("recommended", Gson().toJson(recommended))
+                        putString("upcoming", Gson().toJson(upcoming))
+                        putString("report", Gson().toJson(_popularityReport.value))
+                        apply()
+                    }
 
-                // Calculate number of times user played the most played sport
-                var mostPlayedSportCount = 0
-                if (mostPlayedSport != null && mostPlayedSport.id != "unknown") {
-                    mostPlayedSportCount = user.bookings
-                        .mapNotNull { it.venue?.sport }
-                        .count { it.id == mostPlayedSport.id }
+                } catch (e: Exception) {
+                    Log.e("HomeViewModel", "Error loading online data", e)
                 }
+            } else {
+                Log.w("OfflineMode", "No internet - loading from cache")
+                val recommendedJson = prefs.getString("recommended", null)
+                val upcomingJson = prefs.getString("upcoming", null)
+                val reportJson = prefs.getString("report", null)
 
-                Log.d("PopularityReport", "Fetched: $highestRatedVenue, $mostPlayedSport (played $mostPlayedSportCount times), $mostBookedVenue")
+                _recommendedBookings.value = recommendedJson?.let {
+                    Gson().fromJson(it, object : TypeToken<List<Booking>>() {}.type)
+                } ?: emptyList()
 
-                _popularityReport.value = PopularityReportData(
-                    highestRatedVenue,
-                    mostPlayedSport ?: Sport(id = "unknown", name = "No sport found", logo = ""),
-                    mostPlayedSportCount,
-                    mostBookedVenue,
-                    mostBookedCount
-                )
+                _upcomingBookings.value = upcomingJson?.let {
+                    Gson().fromJson(it, object : TypeToken<List<Booking>>() {}.type)
+                } ?: emptyList()
 
-            } catch (e: Exception) {
-                e.printStackTrace()
-                Log.e("PopularityReport", "Error fetching data", e)
+                _popularityReport.value = reportJson?.let {
+                    Gson().fromJson(it, PopularityReportData::class.java)
+                } ?: PopularityReportData(null, Sport("unknown", "No sport", ""), 0, null, 0)
             }
         }
+    }
+
+    private fun mapReport(
+        report: Map<String, Any?>,
+        user: User
+    ): PopularityReportData {
+        val highestRatedVenue = report["highestRatedVenue"] as? Venue
+        val mostBookedVenue = report["mostBookedVenue"] as? Venue
+        val mostPlayedSport = report["mostPlayedSport"] as? Sport
+        val mostBookedCount = (report["mostBookedVenueWithCount"] as? HomeRepository.VenueWithBookingCount)?.bookingCount ?: 0
+        val mostPlayedSportCount = user.bookings
+            .mapNotNull { it.venue?.sport }
+            .count { it.id == mostPlayedSport?.id }
+
+        return PopularityReportData(
+            highestRatedVenue,
+            mostPlayedSport ?: Sport("unknown", "No sport", ""),
+            mostPlayedSportCount,
+            mostBookedVenue,
+            mostBookedCount
+        )
     }
 }

--- a/app/src/main/res/layout/fragment_home.xml
+++ b/app/src/main/res/layout/fragment_home.xml
@@ -130,6 +130,21 @@
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toBottomOf="@id/recyclerUpcomingBookings" />
 
+            <TextView
+                android:id="@+id/textRecommendedOfflineWarning"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="No recommended bookings available while offline"
+                android:textSize="14sp"
+                android:textColor="@android:color/darker_gray"
+                android:visibility="gone"
+                android:layout_marginTop="4dp"
+                app:layout_constraintTop_toBottomOf="@id/textRecommended"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                android:gravity="center" />
+
+
             <androidx.recyclerview.widget.RecyclerView
                 android:id="@+id/recyclerRecommendedBookings"
                 android:layout_width="match_parent"


### PR DESCRIPTION
This merge should integrate the changes for the eventual connectivity scenario made for the Home View. In this scenario, when the user is not connected to the internet the home view shows the popularity report and upcomming bookings that it retrieves from cache and it show a "no internet connection" message for the suggested bookings of the user. Additionally, when the user has connection again the new popularity report and upcomming bookings are uodated in cache.