### PR TITLE
fix: Venue list elements no longer overlap with bottom navbar

### DIFF
--- a/app/src/main/res/layout/fragment_venue_list.xml
+++ b/app/src/main/res/layout/fragment_venue_list.xml
@@ -1,8 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:orientation="vertical"
     android:background="?attr/colorBackgroundFloating"
     android:padding="16dp">
@@ -28,7 +29,11 @@
     <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/recyclerViewVenues"
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="1"
+        android:clipToPadding="false"
+        android:paddingBottom="60dp"
         android:paddingTop="8dp"/>
 
 </LinearLayout>
+


### PR DESCRIPTION
- Added some extra padding at the bottom. Now the last element in the venue list no longer overlaps with the navigation bar.

![Imagen de WhatsApp 2025-04-25 a las 21 20 33_3f18f12e](https://github.com/user-attachments/assets/569bebc5-d3a6-42bc-9275-2010b175347f)
