### PR TITLE
Feat/47 eventual connectivity search view

### DIFF
--- a/app/src/main/java/com/example/sporthub/data/model/Venue.kt
+++ b/app/src/main/java/com/example/sporthub/data/model/Venue.kt
@@ -13,5 +13,5 @@ data class Venue(
     @PropertyName("name") val name: String = "",
     @PropertyName("rating") val rating: Double = 0.0,
     @PropertyName("sport") val sport: Sport? = null,
-    @PropertyName("bookings") var bookings: List<Booking> = listOf()
+    @PropertyName("bookings") var bookings: List<Booking> ? = null
 )

--- a/app/src/main/java/com/example/sporthub/ui/findVenues/FindVenuesFragment.kt
+++ b/app/src/main/java/com/example/sporthub/ui/findVenues/FindVenuesFragment.kt
@@ -26,14 +26,18 @@ class FindVenuesFragment : Fragment() {
     private val viewModel: FindVenuesViewModel by viewModels()
     private lateinit var recyclerView: RecyclerView
     private lateinit var adapter: SportsAdapter
+    private var connectionFlag = false
+
 
     private val connectivityReceiver = object : BroadcastReceiver() {
         override fun onReceive(context: Context, intent: Intent?) {
-            if (ConnectivityHelper.isNetworkAvailable(context)) {
+            if (ConnectivityHelper.isNetworkAvailable(context) && connectionFlag) {
                 // Refresh the adapter to reload images
                 recyclerView.adapter?.notifyDataSetChanged()
 
                 Snackbar.make(requireView(), "Internet connection restored.", Snackbar.LENGTH_SHORT).show()
+                connectionFlag = false
+
             }
         }
     }
@@ -57,6 +61,7 @@ class FindVenuesFragment : Fragment() {
         recyclerView.adapter = adapter
 
         if (!ConnectivityHelper.isNetworkAvailable(requireContext())) {
+            connectionFlag = true
             Snackbar.make(view, "You are offline. Some venues might not load.", Snackbar.LENGTH_INDEFINITE)
                 .setAction("Dismiss") {} // User can dismiss manually
                 .show()

--- a/app/src/main/java/com/example/sporthub/ui/findVenues/FindVenuesFragment.kt
+++ b/app/src/main/java/com/example/sporthub/ui/findVenues/FindVenuesFragment.kt
@@ -14,6 +14,8 @@ import com.example.sporthub.R
 import com.example.sporthub.data.model.Sport
 import com.example.sporthub.ui.findVenues.SportsAdapter
 import android.widget.Button
+import com.example.sporthub.utils.ConnectivityHelper
+import com.google.android.material.snackbar.Snackbar
 
 class FindVenuesFragment : Fragment() {
 
@@ -37,6 +39,10 @@ class FindVenuesFragment : Fragment() {
         }
 
         recyclerView.adapter = adapter
+
+        if (!ConnectivityHelper.isNetworkAvailable(requireContext())) {
+            Snackbar.make(view, "You are offline. Some venues might not load.", Snackbar.LENGTH_LONG).show()
+        }
 
     }
 

--- a/app/src/main/java/com/example/sporthub/ui/findVenues/FindVenuesViewModel.kt
+++ b/app/src/main/java/com/example/sporthub/ui/findVenues/FindVenuesViewModel.kt
@@ -15,7 +15,7 @@ class FindVenuesViewModel : ViewModel() {
     private val _venues = MutableLiveData<List<Venue>>()
     val venues: LiveData<List<Venue>> get() = _venues
 
-    private val venueCache = mutableMapOf<String, List<Venue>>()
+    val venueCache = mutableMapOf<String, List<Venue>>()
 
     // Lista de deportes disponibles
 

--- a/app/src/main/java/com/example/sporthub/ui/findVenues/FindVenuesViewModel.kt
+++ b/app/src/main/java/com/example/sporthub/ui/findVenues/FindVenuesViewModel.kt
@@ -15,6 +15,8 @@ class FindVenuesViewModel : ViewModel() {
     private val _venues = MutableLiveData<List<Venue>>()
     val venues: LiveData<List<Venue>> get() = _venues
 
+    private val venueCache = mutableMapOf<String, List<Venue>>()
+
     // Lista de deportes disponibles
 
     val sportsList = listOf(
@@ -24,19 +26,36 @@ class FindVenuesViewModel : ViewModel() {
         Sport(id = "tennis", name = "Tennis", logo = "https://firebasestorage.googleapis.com/v0/b/moviles-isis3510.firebasestorage.app/o/icons%2Fsports%2Ftennis-logo.png?alt=media&token=84fde031-9c77-4cc5-b4d3-dd785e203b99")
     )
 
-    fun fetchVenuesBySport(sportId: String) {
+    fun fetchVenuesBySport(sportId: String, forceFetchFromNetwork: Boolean = false) {
+        val cachedVenues = venueCache[sportId]
+
+        if (!forceFetchFromNetwork && !cachedVenues.isNullOrEmpty()) {
+            _venues.value = cachedVenues
+            return
+        }
+
         db.collection("venues")
-            .whereEqualTo("sport.id", sportId)  // Filter by selected sport
+            .whereEqualTo("sport.id", sportId)
             .get()
             .addOnSuccessListener { snapshot: QuerySnapshot ->
                 val venueList = snapshot.documents.mapNotNull { doc ->
                     doc.toObject(Venue::class.java)?.copy(id = doc.id)
                 }
                 _venues.value = venueList
+                venueCache[sportId] = venueList
             }
             .addOnFailureListener {
-                _venues.value = emptyList()  // Handle failure
+                // Only fallback if there's a previous cache
+                if (!cachedVenues.isNullOrEmpty()) {
+                    _venues.value = cachedVenues
+                } else {
+                    _venues.value = emptyList()
+                }
             }
     }
+
+
+
+
 
 }

--- a/app/src/main/java/com/example/sporthub/ui/findVenues/SportsAdapter.kt
+++ b/app/src/main/java/com/example/sporthub/ui/findVenues/SportsAdapter.kt
@@ -21,8 +21,10 @@ class SportsAdapter(
 
         fun bind(sport: Sport) {
             sportName.text = sport.name
-            Glide.with(itemView.context).load(sport.logo).into(sportImage)
-
+            Glide.with(itemView.context)
+                .load(sport.logo)
+                .error(R.drawable.sport_logo)
+                .into(sportImage)
             itemView.setOnClickListener {
                 onItemClick(sport)
             }

--- a/app/src/main/java/com/example/sporthub/ui/findVenues/SportsAdapter.kt
+++ b/app/src/main/java/com/example/sporthub/ui/findVenues/SportsAdapter.kt
@@ -16,15 +16,22 @@ class SportsAdapter(
 ) : RecyclerView.Adapter<SportsAdapter.SportViewHolder>() {
 
     inner class SportViewHolder(view: View) : RecyclerView.ViewHolder(view) {
-        val sportImage: ImageView = view.findViewById(R.id.sportImage)
-        val sportName: TextView = view.findViewById(R.id.sportName)
+        private val sportImage: ImageView = view.findViewById(R.id.sportImage)
+        private val sportName: TextView = view.findViewById(R.id.sportName)
 
         fun bind(sport: Sport) {
             sportName.text = sport.name
+
+            Glide.with(itemView.context)
+                .clear(sportImage)
+
+
             Glide.with(itemView.context)
                 .load(sport.logo)
+                .placeholder(R.drawable.sport_logo)
                 .error(R.drawable.sport_logo)
                 .into(sportImage)
+
             itemView.setOnClickListener {
                 onItemClick(sport)
             }

--- a/app/src/main/java/com/example/sporthub/ui/venueDetail/VenueDetailFragment.kt
+++ b/app/src/main/java/com/example/sporthub/ui/venueDetail/VenueDetailFragment.kt
@@ -18,6 +18,7 @@ import com.example.sporthub.ui.findVenues.FindVenuesViewModel
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import com.example.sporthub.ui.venueDetail.BookingAdapter
+import com.google.android.material.snackbar.Snackbar
 
 class VenueDetailFragment : Fragment() {
 
@@ -57,7 +58,15 @@ class VenueDetailFragment : Fragment() {
         bookingsRecyclerView.layoutManager = LinearLayoutManager(requireContext())
 
 
-        viewModel.fetchVenueById(args.venueId)
+        val cachedVenue = findVenuesViewModel.venueCache.values
+            .flatten()
+            .firstOrNull { it.id == args.venueId }
+
+        if (cachedVenue != null) {
+            viewModel.setVenueFromCache(cachedVenue)
+        } else {
+            viewModel.fetchVenueById(args.venueId)
+        }
 
         viewModel.venue.observe(viewLifecycleOwner) { venue ->
             if (venue != null) {
@@ -81,8 +90,21 @@ class VenueDetailFragment : Fragment() {
 
                 // Log and display bookings
                 Log.d("DEBUG", "Fetched bookings: ${venue.bookings}")
-                println("Fetched bookings: ${venue.bookings}")
                 bookingAdapter.submitList(venue.bookings ?: emptyList())
+            }
+            else {
+                venueName.text = "Venue not available"
+                venueLocation.text = ""
+                venueSport.text = ""
+                venueRating.text = ""
+                venueImage.setImageResource(R.drawable.ic_court_logo) // Optional placeholder image
+
+                bookingAdapter = BookingAdapter("")
+                bookingsRecyclerView.layoutManager = LinearLayoutManager(requireContext())
+                bookingsRecyclerView.adapter = bookingAdapter
+                bookingAdapter.submitList(emptyList())
+
+                Snackbar.make(requireView(), "Unable to load venue details. Please check your connection.", Snackbar.LENGTH_LONG).show()
             }
         }
 

--- a/app/src/main/java/com/example/sporthub/ui/venueDetail/VenueDetailFragment.kt
+++ b/app/src/main/java/com/example/sporthub/ui/venueDetail/VenueDetailFragment.kt
@@ -32,6 +32,9 @@ class VenueDetailFragment : Fragment() {
     private lateinit var venueSport: TextView
     private lateinit var venueRating: TextView
 
+    private val findVenuesViewModel: FindVenuesViewModel by activityViewModels()
+
+
     override fun onCreateView(
         inflater: LayoutInflater,
         container: ViewGroup?,

--- a/app/src/main/java/com/example/sporthub/ui/venueDetail/VenueDetailViewModel.kt
+++ b/app/src/main/java/com/example/sporthub/ui/venueDetail/VenueDetailViewModel.kt
@@ -49,4 +49,8 @@ class VenueDetailViewModel : ViewModel() {
             }
     }
 
+    fun setVenueFromCache(cachedVenue: Venue) {
+        _venue.value = cachedVenue
+    }
+
 }

--- a/app/src/main/java/com/example/sporthub/ui/venueList/VenueListFragment.kt
+++ b/app/src/main/java/com/example/sporthub/ui/venueList/VenueListFragment.kt
@@ -30,6 +30,7 @@ import com.google.android.gms.tasks.CancellationTokenSource
 import java.util.Locale
 import android.widget.TextView
 import com.example.sporthub.utils.ConnectivityHelper
+import com.google.android.material.snackbar.Snackbar
 
 class VenueListFragment : Fragment() {
 
@@ -115,13 +116,14 @@ class VenueListFragment : Fragment() {
             if (venues.isEmpty()) {
                 val hasInternet = ConnectivityHelper.isNetworkAvailable(requireContext())
                 if (!hasInternet) {
-                    Toast.makeText(
-                        requireContext(),
-                        "No internet connection and no cached venues available.",
-                        Toast.LENGTH_LONG
+                    Snackbar.make(
+                        requireView(),
+                        "Unable to load venues list. Please check your internet connection.",
+                        Snackbar.LENGTH_LONG
                     ).show()
                 }
             }
+
 
             val sortedVenues = if (userLocation != null) {
                 sortVenuesByDistance(venues)

--- a/app/src/main/java/com/example/sporthub/ui/venueList/VenueListFragment.kt
+++ b/app/src/main/java/com/example/sporthub/ui/venueList/VenueListFragment.kt
@@ -29,6 +29,7 @@ import com.google.android.gms.location.Priority
 import com.google.android.gms.tasks.CancellationTokenSource
 import java.util.Locale
 import android.widget.TextView
+import com.example.sporthub.utils.ConnectivityHelper
 
 class VenueListFragment : Fragment() {
 
@@ -108,8 +109,20 @@ class VenueListFragment : Fragment() {
 
 
     private fun setupObservers() {
-        viewModel.venues.observe(viewLifecycleOwner, Observer { venues ->
+        viewModel.venues.observe(viewLifecycleOwner) { venues ->
             venuesLoaded = true
+
+            if (venues.isEmpty()) {
+                val hasInternet = ConnectivityHelper.isNetworkAvailable(requireContext())
+                if (!hasInternet) {
+                    Toast.makeText(
+                        requireContext(),
+                        "No internet connection and no cached venues available.",
+                        Toast.LENGTH_LONG
+                    ).show()
+                }
+            }
+
             val sortedVenues = if (userLocation != null) {
                 sortVenuesByDistance(venues)
             } else {
@@ -117,10 +130,10 @@ class VenueListFragment : Fragment() {
             }
             venueAdapter.submitList(sortedVenues)
 
-            // Pass user location to adapter to display distances
             venueAdapter.setUserLocation(userLocation)
-        })
+        }
     }
+
 
     private fun checkLocationPermission() {
         when {
@@ -187,9 +200,11 @@ class VenueListFragment : Fragment() {
 
     private fun loadVenues() {
         sportId?.let { id ->
-            viewModel.fetchVenuesBySport(id)
+            val hasInternet = ConnectivityHelper.isNetworkAvailable(requireContext())
+            viewModel.fetchVenuesBySport(id, forceFetchFromNetwork = hasInternet)
         }
     }
+
 
     private fun sortVenuesByDistance(venues: List<Venue>): List<Venue> {
         val currentLocation = userLocation ?: return venues

--- a/app/src/main/res/layout/fragment_venue_list.xml
+++ b/app/src/main/res/layout/fragment_venue_list.xml
@@ -28,7 +28,10 @@
     <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/recyclerViewVenues"
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="1"
+        android:clipToPadding="false"
+        android:paddingBottom="60dp"
         android:paddingTop="8dp"/>
 
 </LinearLayout>


### PR DESCRIPTION
- Eventual connectivity was implemented for the three fragments that create the search view.
- When the user has connection, and clicks a sport from the "Find Venues" fragment, the fetched venues (Since we have very few, all of them. Might be good to limit this in the future) get cached into a local map array. 
- If connection is unavailable, the fetching will always try network first, if that fails, then i'll check the local cache. if it's there, it will load it, at the same time, there will be a snack bar that notifies that network is unavailable. A example of this situation can be seen in this [video](https://drive.google.com/file/d/15pX914FPT6cLe5nM9xIN8KYCY2FPUacs/view?usp=sharing). 
- If the venues were never fetched in the first place (and the Find Venues fragment was not visited at all). There will be a generic fallback for the sports icons, and the same snackbar notifying network access will be shown. When the user tries to see the venue list, since there's nothing on cache, it will show a snack bar that explains so. It can be seen in this [video](https://drive.google.com/file/d/1kGA439T5tgwxju-UgVmKAJ_VdWXgHYMx/view?usp=sharing). There's a broadcast receiver in the Find venues fragment that will be aware for network updates.
- There will probably be a merge conflict, so expect more commits.