### PR TITLE
Sprint 3 app apk

### DIFF
--- a/app/src/main/java/com/example/sporthub/ui/findVenues/FindVenuesViewModel.kt
+++ b/app/src/main/java/com/example/sporthub/ui/findVenues/FindVenuesViewModel.kt
@@ -29,8 +29,8 @@ class FindVenuesViewModel : ViewModel() {
         val cachedVenues = venueCache[sportId]
 
         if (!forceFetchFromNetwork && !cachedVenues.isNullOrEmpty()) {
-            // Fixed: Use non-null value by using cachedVenues directly (as we've checked it's not null)
-            _venues.value = cachedVenues
+            // Use a non-null empty list as the default
+            _venues.value = cachedVenues ?: emptyList()
             return
         }
 
@@ -47,8 +47,8 @@ class FindVenuesViewModel : ViewModel() {
             .addOnFailureListener {
                 // Only fallback if there's a previous cache
                 if (!cachedVenues.isNullOrEmpty()) {
-                    // Fixed: Use non-null value by using cachedVenues directly
-                    _venues.value = cachedVenues
+                    // Use a non-null empty list as the default
+                    _venues.value = cachedVenues ?: emptyList()
                 } else {
                     _venues.value = emptyList()
                 }


### PR DESCRIPTION
This pull request includes several improvements to the handling of nullable values and default assignments in the `FindVenuesViewModel` and `ProfileViewModel` classes. The changes ensure safer and more consistent behavior by providing non-null default values where necessary.

### Improvements to nullable value handling in `FindVenuesViewModel`:

* Updated `_venues.value` assignment to use a non-null empty list as the default if `cachedVenues` is null. This change was applied in both the conditional check for cached venues and the failure listener. (`app/src/main/java/com/example/sporthub/ui/findVenues/FindVenuesViewModel.kt`, [[1]](diffhunk://#diff-597accb2e8a85350da0249220268f051c8dce27bac8744ff3de13f0bc8f93165L33-R33) [[2]](diffhunk://#diff-597accb2e8a85350da0249220268f051c8dce27bac8744ff3de13f0bc8f93165L50-L60)

### Improvements to nullable value handling in `ProfileViewModel`:

* Fixed the assignment of `savedDarkMode` to `_isDarkMode` by using a safe default value (current theme state) when `savedDarkMode` is null, ensuring no direct assignment of a potentially nullable value. (`app/src/main/java/com/example/sporthub/viewmodel/ProfileViewModel.kt`, [app/src/main/java/com/example/sporthub/viewmodel/ProfileViewModel.ktL115-R117](diffhunk://#diff-5bc64d85be1e102c9489a6a58c631ce639c04d1d442708b9ffa4dabea51d21f3L115-R117))