### PR TITLE
refactor: moved viewmodels to the correct folder

### DIFF
--- a/app/src/main/java/com/example/sporthub/ui/findVenues/FindVenuesFragment.kt
+++ b/app/src/main/java/com/example/sporthub/ui/findVenues/FindVenuesFragment.kt
@@ -16,10 +16,9 @@ import androidx.recyclerview.widget.GridLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import com.example.sporthub.R
 import com.example.sporthub.data.model.Sport
-import com.example.sporthub.ui.findVenues.SportsAdapter
 import com.example.sporthub.utils.ConnectivityHelper
 import com.google.android.material.snackbar.Snackbar
-import com.bumptech.glide.Glide
+import com.example.sporthub.viewmodel.FindVenuesViewModel
 
 class FindVenuesFragment : Fragment() {
 

--- a/app/src/main/java/com/example/sporthub/ui/venueDetail/VenueDetailFragment.kt
+++ b/app/src/main/java/com/example/sporthub/ui/venueDetail/VenueDetailFragment.kt
@@ -13,14 +13,13 @@ import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.navArgs
 import com.bumptech.glide.Glide
 import com.example.sporthub.R
-import com.example.sporthub.data.model.Venue
-import com.example.sporthub.ui.findVenues.FindVenuesViewModel
+import com.example.sporthub.viewmodel.FindVenuesViewModel
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import com.example.sporthub.databinding.FragmentVenueDetailBinding
-import com.example.sporthub.ui.venueDetail.BookingAdapter
 import com.google.android.material.snackbar.Snackbar
 import androidx.navigation.fragment.findNavController
+import com.example.sporthub.viewmodel.VenueDetailViewModel
 
 class VenueDetailFragment : Fragment() {
 

--- a/app/src/main/java/com/example/sporthub/ui/venueList/VenueListFragment.kt
+++ b/app/src/main/java/com/example/sporthub/ui/venueList/VenueListFragment.kt
@@ -15,13 +15,12 @@ import androidx.appcompat.app.AppCompatActivity
 import androidx.core.app.ActivityCompat
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
-import androidx.lifecycle.Observer
 import androidx.navigation.fragment.findNavController
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import com.example.sporthub.R
 import com.example.sporthub.data.model.Venue
-import com.example.sporthub.ui.findVenues.FindVenuesViewModel
+import com.example.sporthub.viewmodel.FindVenuesViewModel
 import com.example.sporthub.ui.venueList.adapter.VenueAdapter
 import com.google.android.gms.location.FusedLocationProviderClient
 import com.google.android.gms.location.LocationServices

--- a/app/src/main/java/com/example/sporthub/viewmodel/FindVenuesViewModel.kt
+++ b/app/src/main/java/com/example/sporthub/viewmodel/FindVenuesViewModel.kt
@@ -1,4 +1,4 @@
-package com.example.sporthub.ui.findVenues
+package com.example.sporthub.viewmodel
 
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
@@ -15,7 +15,7 @@ class FindVenuesViewModel : ViewModel() {
     private val _venues = MutableLiveData<List<Venue>>()
     val venues: LiveData<List<Venue>> get() = _venues
 
-    val venueCache = mutableMapOf<String, List<Venue>>()
+    val venueCache = HashMap<String, List<Venue>>()
 
     // Lista de deportes disponibles
     val sportsList = listOf(

--- a/app/src/main/java/com/example/sporthub/viewmodel/VenueDetailViewModel.kt
+++ b/app/src/main/java/com/example/sporthub/viewmodel/VenueDetailViewModel.kt
@@ -1,4 +1,4 @@
-package com.example.sporthub.ui.venueDetail
+package com.example.sporthub.viewmodel
 
 import android.util.Log
 import androidx.lifecycle.LiveData


### PR DESCRIPTION
This pull request refactors the project structure by reorganizing viewmodels into the already existing `viewmodel `folder.

### Refactoring code organization.

- Reorganized view models into `viewmodel `directory:
   - Updated imports for the `FindVenuesViewModel `and the `VenueDetailViewModel `across some files to reflect their new location inside the `viewmodel `directory. [[1]](https://github.com/Sofiav014/ISIS3510-Team32-Kotlin/compare/develop...refactor/62-organize-project-structure#diff-0507ad5db6ec543e96a3b1d045e3cf2d76fb4a1d042a787af785e442b5f81155) [[2]](https://github.com/Sofiav014/ISIS3510-Team32-Kotlin/compare/develop...refactor/62-organize-project-structure#diff-f16da35b39b4a9465d2400c64939b7640411a2a371dd3818ff4ef40550ee1afb) [[3]](https://github.com/Sofiav014/ISIS3510-Team32-Kotlin/compare/develop...refactor/62-organize-project-structure#diff-54b1c7dd6d706b6a326027f643e8adc33ad73234b9af634cb89cda32e7f43669)
  