### PR TITLE
fix: added filter to include only upcoming bookings

### DIFF
--- a/app/src/main/java/com/example/sporthub/ui/venueDetail/VenueDetailFragment.kt
+++ b/app/src/main/java/com/example/sporthub/ui/venueDetail/VenueDetailFragment.kt
@@ -13,12 +13,9 @@ import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.navArgs
 import com.bumptech.glide.Glide
 import com.example.sporthub.R
-import com.example.sporthub.data.model.Venue
 import com.example.sporthub.ui.findVenues.FindVenuesViewModel
 import androidx.recyclerview.widget.LinearLayoutManager
-import androidx.recyclerview.widget.RecyclerView
 import com.example.sporthub.databinding.FragmentVenueDetailBinding
-import com.example.sporthub.ui.venueDetail.BookingAdapter
 import com.google.android.material.snackbar.Snackbar
 import androidx.navigation.fragment.findNavController
 
@@ -26,23 +23,14 @@ class VenueDetailFragment : Fragment() {
 
     private val args: VenueDetailFragmentArgs by navArgs()
     private val viewModel: VenueDetailViewModel by viewModels()
-    private lateinit var bookingsRecyclerView: RecyclerView
-    private lateinit var bookingAdapter: BookingAdapter
-
-    private lateinit var venueImage: ImageView
-    private lateinit var venueName: TextView
-    private lateinit var venueLocation: TextView
-    private lateinit var venueSport: TextView
-    private lateinit var venueRating: TextView
 
     private val findVenuesViewModel: FindVenuesViewModel by activityViewModels()
 
     private var _binding: FragmentVenueDetailBinding? = null
     private val binding get() = _binding!!
 
-
     private var _bookingAdapter: BookingAdapter? = null
-    private val bookingAdapter2 get() = _bookingAdapter!!
+    private val bookingAdapter get() = _bookingAdapter!!
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -54,17 +42,6 @@ class VenueDetailFragment : Fragment() {
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
-        super.onViewCreated(view, savedInstanceState)
-
-        venueImage = view.findViewById(R.id.venueImageDetail)
-        venueName = view.findViewById(R.id.venueNameDetail)
-        venueLocation = view.findViewById(R.id.venueLocationDetail)
-        venueSport = view.findViewById(R.id.venueSportDetail)
-        venueRating = view.findViewById(R.id.venueRatingDetail)
-
-        bookingsRecyclerView = view.findViewById(R.id.recyclerViewBookings)
-
-        bookingsRecyclerView.layoutManager = LinearLayoutManager(requireContext())
         super.onViewCreated(view, savedInstanceState)
 
         setupRecyclerView()
@@ -84,50 +61,40 @@ class VenueDetailFragment : Fragment() {
 
         viewModel.venue.observe(viewLifecycleOwner) { venue ->
             if (venue != null) {
-                // Initialize adapter with venue name
-                bookingAdapter = BookingAdapter(venue.name)
+                binding.venueNameDetail.text = venue.name
+                binding.venueLocationDetail.text = venue.locationName
+                binding.venueSportDetail.text = venue.sport?.name ?: "Sport name not available"
+                binding.venueRatingDetail.text = String.format("%.1f", venue.rating)
 
-                // Set adapter and layout manager here (moved from earlier)
-                bookingsRecyclerView.layoutManager = LinearLayoutManager(requireContext())
-                bookingsRecyclerView.adapter = bookingAdapter
-
-                // Set venue details
-                venueName.text = venue.name
-                venueLocation.text = venue.name
-                venueSport.text = venue.sport?.name ?: "Sport name not available"
-                venueRating.text = String.format("%.1f", venue.rating)
-
-                // Load venue image
-                Glide.with(requireContext())
+                Glide.with(binding.root.context)
                     .load(venue.image)
-                    .into(venueImage)
+                    .into(binding.venueImageDetail)
 
-                // Log and display bookings
                 Log.d("DEBUG", "Fetched bookings: ${venue.bookings}")
                 bookingAdapter.submitList(venue.bookings ?: emptyList())
-            }
-            else {
-                venueName.text = "Venue not available"
-                venueLocation.text = ""
-                venueSport.text = ""
-                venueRating.text = ""
-                venueImage.setImageResource(R.drawable.ic_court_logo) // Optional placeholder image
+            } else {
+                binding.venueNameDetail.text = "Venue not available"
+                binding.venueLocationDetail.text = ""
+                binding.venueSportDetail.text = ""
+                binding.venueRatingDetail.text = ""
+                binding.venueImageDetail.setImageResource(R.drawable.ic_court_logo)
 
-                bookingAdapter = BookingAdapter("")
-                bookingsRecyclerView.layoutManager = LinearLayoutManager(requireContext())
-                bookingsRecyclerView.adapter = bookingAdapter
                 bookingAdapter.submitList(emptyList())
 
-                Snackbar.make(requireView(), "Unable to load venue details. Please check your connection.", Snackbar.LENGTH_LONG).show()
+                Snackbar.make(
+                    requireView(),
+                    "Unable to load venue details. Please check your connection.",
+                    Snackbar.LENGTH_LONG
+                ).show()
             }
         }
-
     }
+
     private fun setupRecyclerView() {
         _bookingAdapter = BookingAdapter(args.venue.name)
         binding.recyclerViewBookings.apply {
             layoutManager = LinearLayoutManager(requireContext())
-            adapter = bookingAdapter2
+            adapter = bookingAdapter
         }
     }
 
@@ -146,9 +113,6 @@ class VenueDetailFragment : Fragment() {
                 Glide.with(binding.root.context)
                     .load(it.image)
                     .into(binding.venueImageDetail)
-
-                bookingAdapter2.submitList(it.bookings ?: emptyList())
-
             }
         }
     }
@@ -156,9 +120,6 @@ class VenueDetailFragment : Fragment() {
     private fun setupButton() {
         binding.btnCreateBooking.setOnClickListener {
             viewModel.venue.value?.let { venue ->
-
-                android.util.Log.d("VenueDetailFragment", "Navigating with venue: ${venue.name} (${venue.id})")
-
                 val action = VenueDetailFragmentDirections
                     .actionVenueDetailFragmentToNavigationCreate(venue)
                 findNavController().navigate(action)
@@ -169,6 +130,7 @@ class VenueDetailFragment : Fragment() {
     override fun onDestroyView() {
         super.onDestroyView()
         _bookingAdapter = null
-        _binding = null // liberar binding para evitar memory leaks
+        _binding = null
     }
 }
+

--- a/app/src/main/java/com/example/sporthub/ui/venueDetail/VenueDetailViewModel.kt
+++ b/app/src/main/java/com/example/sporthub/ui/venueDetail/VenueDetailViewModel.kt
@@ -8,6 +8,7 @@ import com.example.sporthub.data.model.Booking
 import com.example.sporthub.data.model.Venue
 import com.google.firebase.Timestamp
 import com.google.firebase.firestore.FirebaseFirestore
+import java.util.Date
 
 class VenueDetailViewModel : ViewModel() {
 
@@ -39,7 +40,7 @@ class VenueDetailViewModel : ViewModel() {
                     }
                 } ?: emptyList()
 
-                rawVenue?.bookings = bookingsParsed
+                rawVenue?.bookings = filterUpcomingBookings(bookingsParsed)
                 _venue.value = rawVenue
 
                 Log.d("DEBUG", "Parsed bookings count: ${bookingsParsed.size}")
@@ -56,5 +57,16 @@ class VenueDetailViewModel : ViewModel() {
     fun setVenueFromCache(cachedVenue: Venue) {
         _venue.value = cachedVenue
     }
+
+    private fun filterUpcomingBookings(bookings: List<Booking>): List<Booking> {
+        val now = Date()
+        return bookings.filter { booking ->
+            val startAfterNow = booking.startTime?.toDate()?.after(now) == true
+            val hasAvailableSpots = booking.users.size < booking.maxUsers
+            startAfterNow && hasAvailableSpots
+        }
+    }
+
+
 
 }


### PR DESCRIPTION
This pull request introduces a small yet significant change in the way the bookings are displayed inside the venue detail view. This change affects `VenueDetailViewModel` and `VenueDetailFragment.`

### Significant changes.

- Inside `VenueDetailViewModel`  a new function,  `filterUpcomingBookings` was added. This function, as its name suggests, leaves out both, full bookings and past bookings.  Then, this function is used inside the `fetchVenuesById `function, to only fetch bookings that successfully pass the filter. [[1]](https://github.com/Sofiav014/ISIS3510-Team32-Kotlin/compare/develop...fix/64-filter-elemets-displayed-by-venue-list#diff-4f7eec164b819288f54cee7ae1effbd50af74ee4c1c69c761f7b51d0805121da).
- This filtering effect can be seen in the following figure.
![image](https://github.com/user-attachments/assets/eeef19c5-10ec-4ca9-97d9-8aca8d3e6ce7)

- Additionally, while applying this change, we noticed a redundant `BookingAdapter `inside the  `VenueDetailFragment`, this duplicate could cause fetching problems, and therefore, it was deleted. [[2]](https://github.com/Sofiav014/ISIS3510-Team32-Kotlin/compare/develop...fix/64-filter-elemets-displayed-by-venue-list#diff-9725e65325c5e171b0e8f533cf2dd2a18a00692309241c8b13c599c04051aa55)