### PR TITLE
Feat/65 home view loading time

### DIFF
--- a/app/src/main/java/com/example/sporthub/ui/home/HomeFragment.kt
+++ b/app/src/main/java/com/example/sporthub/ui/home/HomeFragment.kt
@@ -114,7 +114,7 @@ class HomeFragment : Fragment() {
             Log.d("PopularityReport", "Items being submitted: $items")
             popularityAdapter.submitList(items)
 
-            LoadingTimeTracker.stopAndRecord("home view", requireContext())
+            LoadingTimeTracker.stopAndRecord("Home View", requireContext())
         }
 
         homeViewModel.upcomingBookings.observe(viewLifecycleOwner) { bookings ->

--- a/app/src/main/java/com/example/sporthub/ui/home/HomeFragment.kt
+++ b/app/src/main/java/com/example/sporthub/ui/home/HomeFragment.kt
@@ -15,6 +15,8 @@ import com.example.sporthub.data.repository.HomeRepository
 import com.example.sporthub.databinding.FragmentHomeBinding
 import com.example.sporthub.viewmodel.HomeViewModel
 import com.example.sporthub.viewmodel.SharedUserViewModel
+import com.example.sporthub.utils.LoadingTimeTracker
+
 
 class HomeFragment : Fragment() {
 
@@ -36,6 +38,8 @@ class HomeFragment : Fragment() {
         savedInstanceState: Bundle?
     ): View {
         _binding = FragmentHomeBinding.inflate(inflater, container, false)
+
+        LoadingTimeTracker.start()
 
         setupRecyclerViews()
         observeViewModels()
@@ -109,6 +113,8 @@ class HomeFragment : Fragment() {
 
             Log.d("PopularityReport", "Items being submitted: $items")
             popularityAdapter.submitList(items)
+
+            LoadingTimeTracker.stopAndRecord("home view")
         }
 
         homeViewModel.upcomingBookings.observe(viewLifecycleOwner) { bookings ->

--- a/app/src/main/java/com/example/sporthub/ui/home/HomeFragment.kt
+++ b/app/src/main/java/com/example/sporthub/ui/home/HomeFragment.kt
@@ -114,7 +114,7 @@ class HomeFragment : Fragment() {
             Log.d("PopularityReport", "Items being submitted: $items")
             popularityAdapter.submitList(items)
 
-            LoadingTimeTracker.stopAndRecord("home view")
+            LoadingTimeTracker.stopAndRecord("home view", requireContext())
         }
 
         homeViewModel.upcomingBookings.observe(viewLifecycleOwner) { bookings ->

--- a/app/src/main/java/com/example/sporthub/ui/venueDetail/VenueDetailFragment.kt
+++ b/app/src/main/java/com/example/sporthub/ui/venueDetail/VenueDetailFragment.kt
@@ -13,12 +13,9 @@ import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.navArgs
 import com.bumptech.glide.Glide
 import com.example.sporthub.R
-import com.example.sporthub.data.model.Venue
 import com.example.sporthub.ui.findVenues.FindVenuesViewModel
 import androidx.recyclerview.widget.LinearLayoutManager
-import androidx.recyclerview.widget.RecyclerView
 import com.example.sporthub.databinding.FragmentVenueDetailBinding
-import com.example.sporthub.ui.venueDetail.BookingAdapter
 import com.google.android.material.snackbar.Snackbar
 import androidx.navigation.fragment.findNavController
 
@@ -26,23 +23,14 @@ class VenueDetailFragment : Fragment() {
 
     private val args: VenueDetailFragmentArgs by navArgs()
     private val viewModel: VenueDetailViewModel by viewModels()
-    private lateinit var bookingsRecyclerView: RecyclerView
-    private lateinit var bookingAdapter: BookingAdapter
-
-    private lateinit var venueImage: ImageView
-    private lateinit var venueName: TextView
-    private lateinit var venueLocation: TextView
-    private lateinit var venueSport: TextView
-    private lateinit var venueRating: TextView
 
     private val findVenuesViewModel: FindVenuesViewModel by activityViewModels()
 
     private var _binding: FragmentVenueDetailBinding? = null
     private val binding get() = _binding!!
 
-
     private var _bookingAdapter: BookingAdapter? = null
-    private val bookingAdapter2 get() = _bookingAdapter!!
+    private val bookingAdapter get() = _bookingAdapter!!
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -54,17 +42,6 @@ class VenueDetailFragment : Fragment() {
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
-        super.onViewCreated(view, savedInstanceState)
-
-        venueImage = view.findViewById(R.id.venueImageDetail)
-        venueName = view.findViewById(R.id.venueNameDetail)
-        venueLocation = view.findViewById(R.id.venueLocationDetail)
-        venueSport = view.findViewById(R.id.venueSportDetail)
-        venueRating = view.findViewById(R.id.venueRatingDetail)
-
-        bookingsRecyclerView = view.findViewById(R.id.recyclerViewBookings)
-
-        bookingsRecyclerView.layoutManager = LinearLayoutManager(requireContext())
         super.onViewCreated(view, savedInstanceState)
 
         setupRecyclerView()
@@ -84,50 +61,40 @@ class VenueDetailFragment : Fragment() {
 
         viewModel.venue.observe(viewLifecycleOwner) { venue ->
             if (venue != null) {
-                // Initialize adapter with venue name
-                bookingAdapter = BookingAdapter(venue.name)
+                binding.venueNameDetail.text = venue.name
+                binding.venueLocationDetail.text = venue.locationName
+                binding.venueSportDetail.text = venue.sport?.name ?: "Sport name not available"
+                binding.venueRatingDetail.text = String.format("%.1f", venue.rating)
 
-                // Set adapter and layout manager here (moved from earlier)
-                bookingsRecyclerView.layoutManager = LinearLayoutManager(requireContext())
-                bookingsRecyclerView.adapter = bookingAdapter
-
-                // Set venue details
-                venueName.text = venue.name
-                venueLocation.text = venue.name
-                venueSport.text = venue.sport?.name ?: "Sport name not available"
-                venueRating.text = String.format("%.1f", venue.rating)
-
-                // Load venue image
-                Glide.with(requireContext())
+                Glide.with(binding.root.context)
                     .load(venue.image)
-                    .into(venueImage)
+                    .into(binding.venueImageDetail)
 
-                // Log and display bookings
                 Log.d("DEBUG", "Fetched bookings: ${venue.bookings}")
                 bookingAdapter.submitList(venue.bookings ?: emptyList())
-            }
-            else {
-                venueName.text = "Venue not available"
-                venueLocation.text = ""
-                venueSport.text = ""
-                venueRating.text = ""
-                venueImage.setImageResource(R.drawable.ic_court_logo) // Optional placeholder image
+            } else {
+                binding.venueNameDetail.text = "Venue not available"
+                binding.venueLocationDetail.text = ""
+                binding.venueSportDetail.text = ""
+                binding.venueRatingDetail.text = ""
+                binding.venueImageDetail.setImageResource(R.drawable.ic_court_logo)
 
-                bookingAdapter = BookingAdapter("")
-                bookingsRecyclerView.layoutManager = LinearLayoutManager(requireContext())
-                bookingsRecyclerView.adapter = bookingAdapter
                 bookingAdapter.submitList(emptyList())
 
-                Snackbar.make(requireView(), "Unable to load venue details. Please check your connection.", Snackbar.LENGTH_LONG).show()
+                Snackbar.make(
+                    requireView(),
+                    "Unable to load venue details. Please check your connection.",
+                    Snackbar.LENGTH_LONG
+                ).show()
             }
         }
-
     }
+
     private fun setupRecyclerView() {
         _bookingAdapter = BookingAdapter(args.venue.name)
         binding.recyclerViewBookings.apply {
             layoutManager = LinearLayoutManager(requireContext())
-            adapter = bookingAdapter2
+            adapter = bookingAdapter
         }
     }
 
@@ -146,9 +113,6 @@ class VenueDetailFragment : Fragment() {
                 Glide.with(binding.root.context)
                     .load(it.image)
                     .into(binding.venueImageDetail)
-
-                bookingAdapter2.submitList(it.bookings ?: emptyList())
-
             }
         }
     }
@@ -156,9 +120,6 @@ class VenueDetailFragment : Fragment() {
     private fun setupButton() {
         binding.btnCreateBooking.setOnClickListener {
             viewModel.venue.value?.let { venue ->
-
-                android.util.Log.d("VenueDetailFragment", "Navigating with venue: ${venue.name} (${venue.id})")
-
                 val action = VenueDetailFragmentDirections
                     .actionVenueDetailFragmentToNavigationCreate(venue)
                 findNavController().navigate(action)
@@ -169,6 +130,7 @@ class VenueDetailFragment : Fragment() {
     override fun onDestroyView() {
         super.onDestroyView()
         _bookingAdapter = null
-        _binding = null // liberar binding para evitar memory leaks
+        _binding = null
     }
 }
+

--- a/app/src/main/java/com/example/sporthub/ui/venueDetail/VenueDetailViewModel.kt
+++ b/app/src/main/java/com/example/sporthub/ui/venueDetail/VenueDetailViewModel.kt
@@ -8,6 +8,7 @@ import com.example.sporthub.data.model.Booking
 import com.example.sporthub.data.model.Venue
 import com.google.firebase.Timestamp
 import com.google.firebase.firestore.FirebaseFirestore
+import java.util.Date
 
 class VenueDetailViewModel : ViewModel() {
 
@@ -39,7 +40,7 @@ class VenueDetailViewModel : ViewModel() {
                     }
                 } ?: emptyList()
 
-                rawVenue?.bookings = bookingsParsed
+                rawVenue?.bookings = filterUpcomingBookings(bookingsParsed)
                 _venue.value = rawVenue
 
                 Log.d("DEBUG", "Parsed bookings count: ${bookingsParsed.size}")
@@ -56,5 +57,16 @@ class VenueDetailViewModel : ViewModel() {
     fun setVenueFromCache(cachedVenue: Venue) {
         _venue.value = cachedVenue
     }
+
+    private fun filterUpcomingBookings(bookings: List<Booking>): List<Booking> {
+        val now = Date()
+        return bookings.filter { booking ->
+            val startAfterNow = booking.startTime?.toDate()?.after(now) == true
+            val hasAvailableSpots = booking.users.size < booking.maxUsers
+            startAfterNow && hasAvailableSpots
+        }
+    }
+
+
 
 }

--- a/app/src/main/java/com/example/sporthub/utils/LoadingTimeTracker.kt
+++ b/app/src/main/java/com/example/sporthub/utils/LoadingTimeTracker.kt
@@ -17,7 +17,7 @@ object LoadingTimeTracker {
             return
         }
 
-        val duration = System.currentTimeMillis() - startTime
+        val duration = (System.currentTimeMillis() - startTime) / 1000.0
         Log.d("LoadTime", "$screenName loaded in $duration ms")
 
         val docRef = firestore

--- a/app/src/main/java/com/example/sporthub/utils/LoadingTimeTracker.kt
+++ b/app/src/main/java/com/example/sporthub/utils/LoadingTimeTracker.kt
@@ -11,7 +11,12 @@ object LoadingTimeTracker {
         startTime = System.currentTimeMillis()
     }
 
-    fun stopAndRecord(screenName: String) {
+    fun stopAndRecord(screenName: String, context: android.content.Context) {
+        if (!ConnectivityHelper.isNetworkAvailable(context)) {
+            Log.w("LoadTime", "Skipping Firebase update for $screenName due to no connection")
+            return
+        }
+
         val duration = System.currentTimeMillis() - startTime
         Log.d("LoadTime", "$screenName loaded in $duration ms")
 

--- a/app/src/main/java/com/example/sporthub/utils/LoadingTimeTracker.kt
+++ b/app/src/main/java/com/example/sporthub/utils/LoadingTimeTracker.kt
@@ -1,0 +1,51 @@
+package com.example.sporthub.utils
+
+import android.util.Log
+import com.google.firebase.firestore.FirebaseFirestore
+
+object LoadingTimeTracker {
+    private var startTime: Long = 0
+    private val firestore = FirebaseFirestore.getInstance()
+
+    fun start() {
+        startTime = System.currentTimeMillis()
+    }
+
+    fun stopAndRecord(screenName: String) {
+        val duration = System.currentTimeMillis() - startTime
+        Log.d("LoadTime", "$screenName loaded in $duration ms")
+
+        val docRef = firestore
+            .collection("analytics")
+            .document("loading_time")
+            .collection("all")
+            .document(screenName)
+
+        docRef.get().addOnSuccessListener { document ->
+            val currentAvg = (document.getDouble("average_time") ?: 0.0)
+            val visitCount = (document.getLong("visit_count") ?: 0L)
+
+            val newAvg = ((currentAvg * visitCount) + duration) / (visitCount + 1)
+
+            docRef.update(
+                mapOf(
+                    "average_time" to newAvg,
+                    "visit_count" to visitCount + 1
+                )
+            ).addOnSuccessListener {
+                Log.d("LoadTime", "Updated average load time for $screenName")
+            }.addOnFailureListener {
+                Log.w("LoadTime", "Failed to update document, trying set() instead")
+                docRef.set(
+                    mapOf(
+                        "average_time" to duration,
+                        "visit_count" to 1
+                    )
+                )
+            }
+
+        }.addOnFailureListener {
+            Log.e("LoadTime", "Error reading load time data", it)
+        }
+    }
+}


### PR DESCRIPTION

### Feature: Home View Loading Time Tracking

This PR involves the following changes:

* **Loading time tracking** for `HomeFragment` using `System.currentTimeMillis()`
* Created a reusable utility: `LoadingTimeTracker.kt` [[1]](https://github.com/Sofiav014/ISIS3510-Team32-Kotlin/compare/develop...feat/65-home-view-loading-time#diff-c08a4d16616d654e5d4d725f21b78904e2bb6ad72379847a4cfca71d02d082d9)to encapsulate:

  * Start/Stop timing
  * Uploading duration to Firestore under:

    ```
    analytics/
      loading_time/
        all/
          home view/
            average_time
            visit_count
    ```
* This utility was then injected into HomeFragment.kt in order to measure loading time, making use of the OnCreateView() and the ObserveViewModel() function. [[2]](https://github.com/Sofiav014/ISIS3510-Team32-Kotlin/compare/develop...feat/65-home-view-loading-time#diff-aa5e7381b9777cd5e8bbf6be0895b579a791554a6b43caecaa3c03f1ce4a14c8)
* Integrated `ConnectivityHelper` to **prevent Firebase writes if offline**, avoiding unnecessary failures or exceptions. Therefore, `ConnectivityHelper` is now a dependency inside   `LoadingTimeTracker.kt` . [[3]](https://github.com/Sofiav014/ISIS3510-Team32-Kotlin/compare/develop...feat/65-home-view-loading-time#diff-c08a4d16616d654e5d4d725f21b78904e2bb6ad72379847a4cfca71d02d082d9)

* Ignore the "fix: added filter to include only upcoming bookings" commit. This commit was addressed in pull request number 66. [[4]](https://github.com/Sofiav014/ISIS3510-Team32-Kotlin/pull/66) It is unknown why this commit appeared here as well.

* Check how the firestore data base is updated in the following video. [[5]](https://drive.google.com/file/d/1DCgwQEtmkTR0Wj07gXoruwaiUFPQmuoh/view?usp=sharing)
