### PR TITLE
Feat/80 implement local storage venue list

### DIFF
--- a/app/src/main/java/com/example/sporthub/data/model/CachedVenue.kt
+++ b/app/src/main/java/com/example/sporthub/data/model/CachedVenue.kt
@@ -1,0 +1,12 @@
+package com.example.sporthub.data.model
+
+import com.google.firebase.firestore.GeoPoint
+
+data class CachedVenue(
+    val id: String,
+    val coords: GeoPoint?,
+    val locationName: String,
+    val name: String,
+    val rating: Double,
+    val sportId: String
+)

--- a/app/src/main/java/com/example/sporthub/ui/venueDetail/VenueDetailFragment.kt
+++ b/app/src/main/java/com/example/sporthub/ui/venueDetail/VenueDetailFragment.kt
@@ -20,6 +20,8 @@ import com.example.sporthub.databinding.FragmentVenueDetailBinding
 import com.example.sporthub.ui.venueDetail.BookingAdapter
 import com.google.android.material.snackbar.Snackbar
 import androidx.navigation.fragment.findNavController
+import com.example.sporthub.data.model.Sport
+import com.example.sporthub.data.model.Venue
 import com.example.sporthub.viewmodel.VenueDetailViewModel
 
 class VenueDetailFragment : Fragment() {
@@ -77,8 +79,23 @@ class VenueDetailFragment : Fragment() {
             .firstOrNull { it.id == args.venue.id }
 
         if (cachedVenue != null) {
-            viewModel.setVenueFromCache(cachedVenue)
-        } else {
+            val reconstructedVenue = Venue(
+                id = cachedVenue.id,
+                coords = cachedVenue.coords,
+                image = "",
+                locationName = cachedVenue.locationName,
+                name = cachedVenue.name,
+                rating = cachedVenue.rating,
+                sport = Sport(
+                    id = cachedVenue.sportId,
+                    name = "", // Name and logo are not available in cache
+                    logo = ""
+                ),
+                bookings = null
+            )
+            viewModel.setVenueFromCache(reconstructedVenue)
+        }
+else {
             viewModel.fetchVenueById(args.venue.id)
         }
 
@@ -100,7 +117,10 @@ class VenueDetailFragment : Fragment() {
                 // Load venue image
                 Glide.with(requireContext())
                     .load(venue.image)
+                    .placeholder(R.drawable.placeholder_image)
+                    .error(R.drawable.placeholder_image)
                     .into(venueImage)
+
 
                 // Log and display bookings
                 Log.d("DEBUG", "Fetched bookings: ${venue.bookings}")
@@ -145,6 +165,8 @@ class VenueDetailFragment : Fragment() {
 
                 Glide.with(binding.root.context)
                     .load(it.image)
+                    .placeholder(R.drawable.placeholder_image)
+                    .error(R.drawable.placeholder_image)
                     .into(binding.venueImageDetail)
 
                 bookingAdapter2.submitList(it.bookings ?: emptyList())

--- a/app/src/main/java/com/example/sporthub/ui/venueList/VenueAdapter.kt
+++ b/app/src/main/java/com/example/sporthub/ui/venueList/VenueAdapter.kt
@@ -10,6 +10,8 @@ import androidx.recyclerview.widget.RecyclerView
 import com.bumptech.glide.Glide
 import com.example.sporthub.R
 import com.example.sporthub.data.model.Venue
+import com.example.sporthub.utils.ImageUrlStore
+import java.io.File
 
 class VenueAdapter(
     private val onVenueClick: (Venue) -> Unit
@@ -61,9 +63,26 @@ class VenueAdapter(
         holder.venueRating.text = String.format("%.1f", venue.rating.toFloat())
 
         // Load image
-        Glide.with(holder.itemView.context)
-            .load(venue.image)
-            .into(holder.venueImage)
+        val imagePath = venue.image
+        val imageFile = File(imagePath)
+
+        val context = holder.itemView.context
+        val glideRequest = Glide.with(context)
+
+        if (imageFile.exists()) {
+            glideRequest
+                .load(imageFile)
+                .placeholder(R.drawable.placeholder_image)
+                .error(R.drawable.placeholder_image)
+                .into(holder.venueImage)
+        } else {
+            val fallbackUrl = ImageUrlStore.getImageUrl(context, venue.id)
+            glideRequest
+                .load(fallbackUrl)
+                .placeholder(R.drawable.placeholder_image)
+                .error(R.drawable.placeholder_image)
+                .into(holder.venueImage)
+        }
 
         //Handle click on venue
         holder.itemView.setOnClickListener {

--- a/app/src/main/java/com/example/sporthub/ui/venueList/VenueListFragment.kt
+++ b/app/src/main/java/com/example/sporthub/ui/venueList/VenueListFragment.kt
@@ -202,7 +202,7 @@ class VenueListFragment : Fragment() {
     private fun loadVenues() {
         sportId?.let { id ->
             val hasInternet = ConnectivityHelper.isNetworkAvailable(requireContext())
-            viewModel.fetchVenuesBySport(id, forceFetchFromNetwork = hasInternet)
+            viewModel.fetchVenuesBySport(id, forceFetchFromNetwork = hasInternet, appContext = requireContext())
         }
     }
 

--- a/app/src/main/java/com/example/sporthub/ui/venueList/VenueListFragment.kt
+++ b/app/src/main/java/com/example/sporthub/ui/venueList/VenueListFragment.kt
@@ -28,8 +28,10 @@ import com.google.android.gms.location.Priority
 import com.google.android.gms.tasks.CancellationTokenSource
 import java.util.Locale
 import android.widget.TextView
+import androidx.lifecycle.lifecycleScope
 import com.example.sporthub.utils.ConnectivityHelper
 import com.google.android.material.snackbar.Snackbar
+import kotlinx.coroutines.launch
 
 class VenueListFragment : Fragment() {
 
@@ -202,7 +204,14 @@ class VenueListFragment : Fragment() {
     private fun loadVenues() {
         sportId?.let { id ->
             val hasInternet = ConnectivityHelper.isNetworkAvailable(requireContext())
-            viewModel.fetchVenuesBySport(id, forceFetchFromNetwork = hasInternet, appContext = requireContext())
+            lifecycleScope.launch {
+                viewModel.fetchVenuesBySport(
+                    sportId = id,
+                    forceFetchFromNetwork = hasInternet,
+                    appContext = requireContext().applicationContext
+                )
+            }
+
         }
     }
 

--- a/app/src/main/java/com/example/sporthub/utils/ImageUrlStore.kt
+++ b/app/src/main/java/com/example/sporthub/utils/ImageUrlStore.kt
@@ -1,0 +1,21 @@
+package com.example.sporthub.utils
+
+import android.content.Context
+import android.content.SharedPreferences
+
+object ImageUrlStore {
+    private const val PREF_NAME = "venue_image_urls"
+    private const val KEY_PREFIX = "venue_image_url_"
+
+    private fun getPrefs(context: Context): SharedPreferences {
+        return context.getSharedPreferences(PREF_NAME, Context.MODE_PRIVATE)
+    }
+
+    fun saveImageUrl(context: Context, venueId: String, url: String) {
+        getPrefs(context).edit().putString(KEY_PREFIX + venueId, url).apply()
+    }
+
+    fun getImageUrl(context: Context, venueId: String): String {
+        return getPrefs(context).getString(KEY_PREFIX + venueId, "") ?: ""
+    }
+}

--- a/app/src/main/java/com/example/sporthub/utils/LRUCache.kt
+++ b/app/src/main/java/com/example/sporthub/utils/LRUCache.kt
@@ -1,0 +1,25 @@
+package com.example.sporthub.utils
+
+class LRUCache<K, V>(private val maxSize: Int) {
+
+    private val cache: LinkedHashMap<K, V> = object : LinkedHashMap<K, V>(maxSize, 0.75f, true) {
+        override fun removeEldestEntry(eldest: MutableMap.MutableEntry<K, V>): Boolean {
+            return size > maxSize
+        }
+    }
+
+    operator fun get(key: K): V? = cache[key]
+
+    operator fun set(key: K, value: V) {
+        cache[key] = value
+    }
+
+    fun remove(key: K): V? = cache.remove(key)
+
+    fun clear() = cache.clear()
+
+    val keys: Set<K> get() = cache.keys
+    val values: Collection<V> get() = cache.values
+    val entries: Set<Map.Entry<K, V>> get() = cache.entries
+    val size: Int get() = cache.size
+}

--- a/app/src/main/java/com/example/sporthub/viewmodel/FindVenuesViewModel.kt
+++ b/app/src/main/java/com/example/sporthub/viewmodel/FindVenuesViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import com.example.sporthub.data.model.Sport
 import com.example.sporthub.data.model.Venue
+import com.example.sporthub.utils.LRUCache
 import com.google.firebase.firestore.FirebaseFirestore
 import com.google.firebase.firestore.QuerySnapshot
 
@@ -15,7 +16,7 @@ class FindVenuesViewModel : ViewModel() {
     private val _venues = MutableLiveData<List<Venue>>()
     val venues: LiveData<List<Venue>> get() = _venues
 
-    val venueCache = HashMap<String, List<Venue>>()
+    val venueCache = LRUCache<String, List<Venue>>(maxSize = 20)
 
     // Lista de deportes disponibles
     val sportsList = listOf(

--- a/app/src/main/java/com/example/sporthub/viewmodel/FindVenuesViewModel.kt
+++ b/app/src/main/java/com/example/sporthub/viewmodel/FindVenuesViewModel.kt
@@ -1,13 +1,17 @@
 package com.example.sporthub.viewmodel
 
+import android.content.Context
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
+import com.example.sporthub.data.model.CachedVenue
 import com.example.sporthub.data.model.Sport
 import com.example.sporthub.data.model.Venue
+import com.example.sporthub.utils.ImageUrlStore
 import com.example.sporthub.utils.LRUCache
 import com.google.firebase.firestore.FirebaseFirestore
 import com.google.firebase.firestore.QuerySnapshot
+import java.io.File
 
 class FindVenuesViewModel : ViewModel() {
 
@@ -16,7 +20,8 @@ class FindVenuesViewModel : ViewModel() {
     private val _venues = MutableLiveData<List<Venue>>()
     val venues: LiveData<List<Venue>> get() = _venues
 
-    val venueCache = LRUCache<String, List<Venue>>(maxSize = 20)
+    val venueCache = LRUCache<String, List<CachedVenue>>(maxSize = 20)
+
 
     // Lista de deportes disponibles
     val sportsList = listOf(
@@ -26,12 +31,48 @@ class FindVenuesViewModel : ViewModel() {
         Sport(id = "tennis", name = "Tennis", logo = "https://firebasestorage.googleapis.com/v0/b/moviles-isis3510.firebasestorage.app/o/icons%2Fsports%2Ftennis-logo.png?alt=media&token=84fde031-9c77-4cc5-b4d3-dd785e203b99")
     )
 
-    fun fetchVenuesBySport(sportId: String, forceFetchFromNetwork: Boolean = false) {
+    private fun saveImageToInternalStorage(context: Context, url: String, filename: String): String? {
+        return try {
+            val input = java.net.URL(url).openStream()
+            val file = File(context.filesDir, filename)
+            file.outputStream().use { input.copyTo(it) }
+            file.absolutePath
+        } catch (e: Exception) {
+            e.printStackTrace()
+            null
+        }
+    }
+
+    private fun deleteUnusedVenueImages(context: Context, activeVenueIds: Set<String>) {
+        val filesDir = context.filesDir
+        filesDir.listFiles()?.forEach { file ->
+            if (file.name.startsWith("venue_") && file.name.endsWith(".jpg")) {
+                val id = file.name.removePrefix("venue_").removeSuffix(".jpg")
+                if (id !in activeVenueIds) {
+                    file.delete()
+                }
+            }
+        }
+    }
+
+
+
+    fun fetchVenuesBySport(sportId: String, forceFetchFromNetwork: Boolean = false, appContext: Context) {
         val cachedVenues = venueCache[sportId]
 
         if (!forceFetchFromNetwork && !cachedVenues.isNullOrEmpty()) {
-            // Use a non-null empty list as the default
-            _venues.value = cachedVenues ?: emptyList()
+            _venues.value = cachedVenues.map { cached ->
+                Venue(
+                    id = cached.id,
+                    coords = cached.coords,
+                    image = "", // Placeholder or load from local storage if needed
+                    locationName = cached.locationName,
+                    name = cached.name,
+                    rating = cached.rating,
+                    sport = Sport(id = cached.sportId, name = "", logo = ""), // Or null if not needed
+                    bookings = null // Not needed in cache
+                )
+            }
             return
         }
 
@@ -39,20 +80,61 @@ class FindVenuesViewModel : ViewModel() {
             .whereEqualTo("sport.id", sportId)
             .get()
             .addOnSuccessListener { snapshot: QuerySnapshot ->
-                val venueList = snapshot.documents.mapNotNull { doc ->
+                val rawList = snapshot.documents.mapNotNull { doc ->
                     doc.toObject(Venue::class.java)?.copy(id = doc.id)
                 }
+
+                val venueList = rawList.map { venue ->
+                    val filename = "venue_${venue.id}.jpg"
+                    val imageFile = File(appContext.filesDir, filename)
+
+                    val imagePath = if (imageFile.exists()) {
+                        imageFile.absolutePath
+                    } else {
+                        val path = saveImageToInternalStorage(appContext, venue.image, filename)
+                        ImageUrlStore.saveImageUrl(appContext, venue.id, venue.image)
+                        path ?: ""
+                    }
+
+                    venue.copy(image = imagePath)
+                }
+
+                deleteUnusedVenueImages(appContext, venueList.map { it.id }.toSet())
+
                 _venues.value = venueList
-                venueCache[sportId] = venueList
+
+                val cachedList = venueList.map { venue ->
+                    CachedVenue(
+                        id = venue.id,
+                        coords = venue.coords,
+                        locationName = venue.locationName,
+                        name = venue.name,
+                        rating = venue.rating,
+                        sportId = venue.sport?.id ?: ""
+                    )
+                }
+
+                venueCache[sportId] = cachedList
             }
+
             .addOnFailureListener {
-                // Only fallback if there's a previous cache
                 if (!cachedVenues.isNullOrEmpty()) {
-                    // Use a non-null empty list as the default
-                    _venues.value = cachedVenues ?: emptyList()
+                    _venues.value = cachedVenues.map { cached ->
+                        Venue(
+                            id = cached.id,
+                            coords = cached.coords,
+                            image = "",
+                            locationName = cached.locationName,
+                            name = cached.name,
+                            rating = cached.rating,
+                            sport = Sport(id = cached.sportId, name = "", logo = ""),
+                            bookings = null
+                        )
+                    }
                 } else {
                     _venues.value = emptyList()
                 }
             }
     }
+
 }

--- a/app/src/main/java/com/example/sporthub/viewmodel/FindVenuesViewModel.kt
+++ b/app/src/main/java/com/example/sporthub/viewmodel/FindVenuesViewModel.kt
@@ -11,6 +11,9 @@ import com.example.sporthub.utils.ImageUrlStore
 import com.example.sporthub.utils.LRUCache
 import com.google.firebase.firestore.FirebaseFirestore
 import com.google.firebase.firestore.QuerySnapshot
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import kotlinx.coroutines.tasks.await
 import java.io.File
 
 class FindVenuesViewModel : ViewModel() {
@@ -57,34 +60,43 @@ class FindVenuesViewModel : ViewModel() {
 
 
 
-    fun fetchVenuesBySport(sportId: String, forceFetchFromNetwork: Boolean = false, appContext: Context) {
+    suspend fun fetchVenuesBySport(
+        sportId: String,
+        forceFetchFromNetwork: Boolean = false,
+        appContext: Context
+    ) {
         val cachedVenues = venueCache[sportId]
 
         if (!forceFetchFromNetwork && !cachedVenues.isNullOrEmpty()) {
-            _venues.value = cachedVenues.map { cached ->
-                Venue(
-                    id = cached.id,
-                    coords = cached.coords,
-                    image = "", // Placeholder or load from local storage if needed
-                    locationName = cached.locationName,
-                    name = cached.name,
-                    rating = cached.rating,
-                    sport = Sport(id = cached.sportId, name = "", logo = ""), // Or null if not needed
-                    bookings = null // Not needed in cache
-                )
+            withContext(Dispatchers.Main) {
+                _venues.value = cachedVenues.map { cached ->
+                    Venue(
+                        id = cached.id,
+                        coords = cached.coords,
+                        image = "",
+                        locationName = cached.locationName,
+                        name = cached.name,
+                        rating = cached.rating,
+                        sport = Sport(id = cached.sportId, name = "", logo = ""),
+                        bookings = null
+                    )
+                }
             }
             return
         }
 
-        db.collection("venues")
-            .whereEqualTo("sport.id", sportId)
-            .get()
-            .addOnSuccessListener { snapshot: QuerySnapshot ->
+        try {
+            val venueList = withContext(Dispatchers.IO) {
+                val snapshot = db.collection("venues")
+                    .whereEqualTo("sport.id", sportId)
+                    .get()
+                    .await()
+
                 val rawList = snapshot.documents.mapNotNull { doc ->
                     doc.toObject(Venue::class.java)?.copy(id = doc.id)
                 }
 
-                val venueList = rawList.map { venue ->
+                val processedList = rawList.map { venue ->
                     val filename = "venue_${venue.id}.jpg"
                     val imageFile = File(appContext.filesDir, filename)
 
@@ -99,8 +111,11 @@ class FindVenuesViewModel : ViewModel() {
                     venue.copy(image = imagePath)
                 }
 
-                deleteUnusedVenueImages(appContext, venueList.map { it.id }.toSet())
+                deleteUnusedVenueImages(appContext, processedList.map { it.id }.toSet())
+                processedList
+            }
 
+            withContext(Dispatchers.Main) {
                 _venues.value = venueList
 
                 val cachedList = venueList.map { venue ->
@@ -117,7 +132,8 @@ class FindVenuesViewModel : ViewModel() {
                 venueCache[sportId] = cachedList
             }
 
-            .addOnFailureListener {
+        } catch (e: Exception) {
+            withContext(Dispatchers.Main) {
                 if (!cachedVenues.isNullOrEmpty()) {
                     _venues.value = cachedVenues.map { cached ->
                         Venue(
@@ -135,6 +151,8 @@ class FindVenuesViewModel : ViewModel() {
                     _venues.value = emptyList()
                 }
             }
+        }
     }
+
 
 }


### PR DESCRIPTION
# Implemented changes.

This PR introduces several enhancements for offline scenarios and focuses on overall performance improvements. Major changes include:

* Implemented local storage for venue's images, to reduce load assigned to the caching structure.
* Implemented multithreading with coroutines to delegate I/O operations from the viewmodel to its corresponfing dispatcher.

Additionally, one minor change was made:

* Changed the local cache data structure from HashMap to LRUCache.

## Changes' details

### Major Changes - Local Storage

1. Firstly, a new data model was added, `CachedVenue`. This is a lightweight version of the usual `Venue `data model. The only difference is that `CachedVenue` does not contain the image attribute. [[1]](https://github.com/Sofiav014/ISIS3510-Team32-Kotlin/compare/develop...feat/80-implement-local-storage-venue-list#diff-c8ab0f7ce7ee806aeed009252354373a11fb62685d70e3bed592f06efd023312)
2. Updated `FindVenuesViewModel `to store `CachedVenues `into the cache, additionally, on retrieval, it rebuilds the original `Venue  `object. [[2]](https://github.com/Sofiav014/ISIS3510-Team32-Kotlin/compare/develop...feat/80-implement-local-storage-venue-list#diff-7e78c3006352ed42b3f167b5074cee792a3e90e56c20b4685f3bcc6e42f1872a)
3. Added new utility, `ImageUrlStore`, to save URLs from the images to `SharedPreferences`. [[3]](https://github.com/Sofiav014/ISIS3510-Team32-Kotlin/compare/develop...feat/80-implement-local-storage-venue-list#diff-b9f3e9c16874d69d5f9c1db3b7d416dbb8a724de5aa9abcc8d858122261a5aee)
4. When fetching venues, its corresponding images get downloaded to local storage, local files (not to be confused with local media), and the original URL is saved inside `SharedPreferences`. [[4]](https://github.com/Sofiav014/ISIS3510-Team32-Kotlin/compare/develop...feat/80-implement-local-storage-venue-list#diff-7e78c3006352ed42b3f167b5074cee792a3e90e56c20b4685f3bcc6e42f1872a)
5. Updated `VenueAdapter` [[5]](https://github.com/Sofiav014/ISIS3510-Team32-Kotlin/compare/develop...feat/80-implement-local-storage-venue-list#diff-0ba8bc8117c11bd7e96f888f1e4a6cac88d852ddc7b22eff2f8664435e60afd7) and `VenueDetailFragment` [[6]](https://github.com/Sofiav014/ISIS3510-Team32-Kotlin/compare/develop...feat/80-implement-local-storage-venue-list#diff-9725e65325c5e171b0e8f533cf2dd2a18a00692309241c8b13c599c04051aa55) to:
    - Load images from local file if available
    - Fallback to original URL via `SharedPreferences`
    - Show a placeholder image using `.placeholder()` and `.error()` in Glide
6. As a bonus optimization, the method `FetchVenuesBySportID `was configured to avoid redundant downloads and to clean unreferenced images from the local files. [[7]](https://github.com/Sofiav014/ISIS3510-Team32-Kotlin/compare/develop...feat/80-implement-local-storage-venue-list#diff-7e78c3006352ed42b3f167b5074cee792a3e90e56c20b4685f3bcc6e42f1872a)

### Major changes - Multithreading

- Updated FindVenuesViewModel() to implement Kotlin coroutines, making use of the `I/O distpacther` when fetching the venue data and the image downloading and the switching back to `Main Dispatcher` to send the data to the UI and cache the information. [[8]](https://github.com/Sofiav014/ISIS3510-Team32-Kotlin/compare/develop...feat/80-implement-local-storage-venue-list#diff-7e78c3006352ed42b3f167b5074cee792a3e90e56c20b4685f3bcc6e42f1872a)
- Updated `VenueListFragment `to launch the coroutine inside the fragments scope. [[9]](https://github.com/Sofiav014/ISIS3510-Team32-Kotlin/compare/develop...feat/80-implement-local-storage-venue-list#diff-f16da35b39b4a9465d2400c64939b7640411a2a371dd3818ff4ef40550ee1afb)

### Minor change 

- Created a new class called `LRUCache`, this was made to make use of Kotlin's Hashmap methods (Brackets indexation, get values, get keys) because the usual, `AndroidUtil `implementation `LruCache `could not do that. [[10]](https://github.com/Sofiav014/ISIS3510-Team32-Kotlin/compare/develop...feat/80-implement-local-storage-venue-list#diff-5746331711b6309ae0e369dc69d860d37dac48fd2735d76c6acde34ffb6fb9be)
- Modified the `FindVenuesViewModel `to use `LRUCache `instead of `HashMap()` [[11]](https://github.com/Sofiav014/ISIS3510-Team32-Kotlin/compare/develop...feat/80-implement-local-storage-venue-list#diff-7e78c3006352ed42b3f167b5074cee792a3e90e56c20b4685f3bcc6e42f1872a) setting it to a maximum of 20 elements.