### PR TITLE
Fix/83 sql fav venues

### DIFF
--- a/.idea/kotlinc.xml
+++ b/.idea/kotlinc.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="KotlinJpsPluginSettings">
-    <option name="version" value="1.8.0" />
+    <option name="version" value="1.9.24" />
   </component>
 </project>

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -3,10 +3,10 @@ plugins {
     id("org.jetbrains.kotlin.android")
     id("com.google.gms.google-services")
     id("com.google.firebase.crashlytics")
-    // Reemplaza kapt con ksp para versiones más recientes de Kotlin
-    id("com.google.devtools.ksp") version "1.8.0-1.0.9"
     id("androidx.navigation.safeargs.kotlin")
     id("kotlin-parcelize")
+    // Only use one kapt plugin
+    id("kotlin-kapt")
 }
 
 android {
@@ -39,66 +39,79 @@ android {
         jvmTarget = "11"
     }
 
-    // Agregar soporte para viewBinding y dataBinding
+    // Support for viewBinding and dataBinding
     buildFeatures {
         viewBinding = true
         dataBinding = true
     }
+
+    // Single kapt block with correct config
+    kapt {
+        correctErrorTypes = true
+        useBuildCache = true
+        arguments {
+            arg("room.schemaLocation", "$projectDir/schemas")
+            arg("room.incremental", "true")
+            arg("room.expandProjection", "true")
+            // Removed room.generateKotlin since it requires KSP
+        }
+    }
 }
+
+// Define versions in one place
+val coroutinesVersion = "1.7.3"
+val roomVersion = "2.6.1"
 
 dependencies {
     // Firebase BoM
-
-    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-play-services:1.7.3")
     implementation(platform("com.google.firebase:firebase-bom:32.3.1"))
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-play-services:$coroutinesVersion")
 
-    // Firebase Crashlytics and Analytics
+    // Firebase
     implementation("com.google.firebase:firebase-crashlytics")
     implementation("com.google.firebase:firebase-analytics")
-
-    // Otras dependencias de Firebase que necesitas
     implementation("com.google.firebase:firebase-auth-ktx")
     implementation("com.google.firebase:firebase-database-ktx")
     implementation("com.google.firebase:firebase-firestore-ktx")
 
+    // AndroidX Core
+    implementation("androidx.core:core-ktx:1.12.0")
     implementation("androidx.appcompat:appcompat:1.6.1")
     implementation("com.google.android.material:material:1.10.0")
     implementation("androidx.constraintlayout:constraintlayout:2.1.4")
-
-    // Otras dependencias de AndroidX que podrías necesitar
-    implementation("androidx.core:core-ktx:1.12.0")
     implementation("androidx.activity:activity-ktx:1.8.0")
     implementation("androidx.fragment:fragment-ktx:1.6.1")
 
+    // Navigation
     implementation("androidx.navigation:navigation-fragment-ktx:2.7.5")
     implementation("androidx.navigation:navigation-ui-ktx:2.7.5")
 
-    // *** DEPENDENCIAS FALTANTES ***
-
-    // Lifecycle components
+    // Lifecycle
     implementation("androidx.lifecycle:lifecycle-livedata-ktx:2.6.2")
     implementation("androidx.lifecycle:lifecycle-viewmodel-ktx:2.6.2")
 
-    // Google Sign-In (soluciona errores de GoogleSignIn)
+    // Google Services
     implementation("com.google.android.gms:play-services-auth:20.7.0")
+    implementation("com.google.android.gms:play-services-location:21.0.1")
 
-    // Glide para cargar imágenes (soluciona errores de Glide/bumptech)
+    // Glide
     implementation("com.github.bumptech.glide:glide:4.15.1")
     annotationProcessor("com.github.bumptech.glide:compiler:4.15.1")
 
-    // Servicios de ubicación (soluciona errores de LocationServices)
-    implementation("com.google.android.gms:play-services-location:21.0.1")
+    // Gson
+    implementation("com.google.code.gson:gson:2.10.1")
+
+    // Coroutines - use consistent version
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:$coroutinesVersion")
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:$coroutinesVersion")
+
+    // Room
+    implementation("androidx.room:room-runtime:$roomVersion")
+    implementation("androidx.room:room-ktx:$roomVersion")
+    kapt("androidx.room:room-compiler:$roomVersion")
 
     // Testing
     testImplementation("junit:junit:4.13.2")
     androidTestImplementation("androidx.test.ext:junit:1.1.5")
     androidTestImplementation("androidx.test.espresso:espresso-core:3.5.1")
-
-    // Para caching
-    implementation("com.google.code.gson:gson:2.10.1")
-
-    //corputines
-    implementation ("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.5.2")
-    implementation ("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.5.2")
-
 }

--- a/app/src/main/java/com/example/sporthub/SportHubApplication.kt
+++ b/app/src/main/java/com/example/sporthub/SportHubApplication.kt
@@ -2,6 +2,7 @@ package com.example.sporthub
 
 import android.app.Application
 import android.util.Log
+import com.example.sporthub.data.db.AppDatabase
 import com.example.sporthub.utils.ThemeManager
 
 class SportHubApplication : Application() {
@@ -9,7 +10,7 @@ class SportHubApplication : Application() {
         // Add variable to track if registration is in progress
         var isRegistrationInProgress = false
     }
-
+    val database by lazy { AppDatabase.getDatabase(this) }
     override fun onCreate() {
         super.onCreate()
 

--- a/app/src/main/java/com/example/sporthub/data/db/AppDatabase.kt
+++ b/app/src/main/java/com/example/sporthub/data/db/AppDatabase.kt
@@ -1,0 +1,33 @@
+// app/src/main/java/com/example/sporthub/data/db/AppDatabase.kt
+package com.example.sporthub.data.db
+
+import android.content.Context
+import androidx.room.Database
+import androidx.room.Room
+import androidx.room.RoomDatabase
+import androidx.room.TypeConverters
+
+@Database(entities = [VenueEntity::class], version = 1, exportSchema = false)
+@TypeConverters(Converters::class)
+abstract class AppDatabase : RoomDatabase() {
+    abstract fun favoriteVenueDao(): FavoriteVenueDao
+
+    companion object {
+        @Volatile
+        private var INSTANCE: AppDatabase? = null
+
+        fun getDatabase(context: Context): AppDatabase {
+            return INSTANCE ?: synchronized(this) {
+                val instance = Room.databaseBuilder(
+                    context.applicationContext,
+                    AppDatabase::class.java,
+                    "sporthub_database"
+                )
+                    .fallbackToDestructiveMigration()
+                    .build()
+                INSTANCE = instance
+                instance
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/example/sporthub/data/db/Converters.kt
+++ b/app/src/main/java/com/example/sporthub/data/db/Converters.kt
@@ -1,0 +1,43 @@
+// app/src/main/java/com/example/sporthub/data/db/Converters.kt
+package com.example.sporthub.data.db
+
+import androidx.room.TypeConverter
+import java.util.Date
+
+/**
+ * Minimal type converters for Room database
+ * Only including converters needed for our entity
+ */
+class Converters {
+    /**
+     * Convert Long timestamp to Date
+     */
+    @TypeConverter
+    fun fromTimestamp(value: Long?): Date? {
+        return value?.let { Date(it) }
+    }
+
+    /**
+     * Convert Date to Long timestamp
+     */
+    @TypeConverter
+    fun dateToTimestamp(date: Date?): Long? {
+        return date?.time
+    }
+
+    /**
+     * Convert Boolean to Int for better SQLite compatibility
+     */
+    @TypeConverter
+    fun fromBoolean(value: Boolean): Int {
+        return if (value) 1 else 0
+    }
+
+    /**
+     * Convert Int to Boolean for better SQLite compatibility
+     */
+    @TypeConverter
+    fun toBoolean(value: Int): Boolean {
+        return value == 1
+    }
+}

--- a/app/src/main/java/com/example/sporthub/data/db/FavoriteVenueDao.kt
+++ b/app/src/main/java/com/example/sporthub/data/db/FavoriteVenueDao.kt
@@ -1,0 +1,54 @@
+// app/src/main/java/com/example/sporthub/data/db/FavoriteVenueDao.kt
+package com.example.sporthub.data.db
+
+import androidx.room.*
+import kotlinx.coroutines.flow.Flow
+
+/**
+ * Data Access Object for favorite venues
+ * NOTE: No suspend functions to avoid kapt processing issues
+ */
+@Dao
+interface FavoriteVenueDao {
+    /**
+     * Get stream of favorite venues for a user
+     */
+    @Query("SELECT * FROM favorite_venues WHERE userId = :userId AND isFavorite = 1")
+    fun getAllFavoriteVenues(userId: String): Flow<List<VenueEntity>>
+
+    /**
+     * Insert a single venue
+     */
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    fun insertVenue(venue: VenueEntity): Long
+
+    /**
+     * Insert multiple venues at once
+     */
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    fun insertVenues(venues: List<VenueEntity>): List<Long>
+
+    /**
+     * Mark a venue as not favorite (soft delete)
+     */
+    @Query("UPDATE favorite_venues SET isFavorite = 0 WHERE id = :venueId AND userId = :userId")
+    fun removeFromFavorites(venueId: String, userId: String): Int
+
+    /**
+     * Get a specific favorite venue
+     */
+    @Query("SELECT * FROM favorite_venues WHERE id = :venueId AND userId = :userId AND isFavorite = 1 LIMIT 1")
+    fun getFavoriteVenue(venueId: String, userId: String): VenueEntity?
+
+    /**
+     * Get venues updated after a timestamp
+     */
+    @Query("SELECT * FROM favorite_venues WHERE lastSyncedTimestamp > :timestamp AND userId = :userId")
+    fun getVenuesUpdatedAfter(timestamp: Long, userId: String): List<VenueEntity>
+
+    /**
+     * Permanently delete a venue
+     */
+    @Query("DELETE FROM favorite_venues WHERE id = :venueId AND userId = :userId")
+    fun deleteVenue(venueId: String, userId: String): Int
+}

--- a/app/src/main/java/com/example/sporthub/data/db/VenueEntity.kt
+++ b/app/src/main/java/com/example/sporthub/data/db/VenueEntity.kt
@@ -1,0 +1,70 @@
+package com.example.sporthub.data.db
+
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+import com.example.sporthub.data.model.Sport
+import com.example.sporthub.data.model.Venue
+
+/**
+ * Room entity for favorite venues
+ * This is separate from the Venue model class to avoid Room processing issues
+ */
+@Entity(tableName = "favorite_venues")
+data class VenueEntity(
+    @PrimaryKey
+    val id: String,
+    val userId: String,
+    val isFavorite: Boolean = true,
+    val lastSyncedTimestamp: Long = System.currentTimeMillis(),
+    // Properties from Venue
+    val name: String = "",
+    val locationName: String = "",
+    val image: String = "",
+    val rating: Double = 0.0,
+    // Sport is stored as separate primitive fields for Room compatibility
+    val sportId: String? = null,
+    val sportName: String? = null,
+    val sportLogo: String? = null
+) {
+    /**
+     * Convert to Venue model object
+     */
+    fun toVenue(): Venue {
+        return Venue(
+            id = id,
+            name = name,
+            locationName = locationName,
+            image = image,
+            rating = rating,
+            sport = if (sportId != null) {
+                Sport(
+                    id = sportId,
+                    name = sportName ?: "",
+                    logo = sportLogo ?: ""
+                )
+            } else null,
+            // Other fields default to null
+            coords = null,
+            bookings = null
+        )
+    }
+
+    companion object {
+        /**
+         * Create VenueEntity from Venue model object
+         */
+        fun fromVenue(venue: Venue, userId: String): VenueEntity {
+            return VenueEntity(
+                id = venue.id,
+                userId = userId,
+                name = venue.name,
+                locationName = venue.locationName,
+                image = venue.image,
+                rating = venue.rating,
+                sportId = venue.sport?.id,
+                sportName = venue.sport?.name,
+                sportLogo = venue.sport?.logo
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/example/sporthub/data/repository/FavoriteVenueRepository.kt
+++ b/app/src/main/java/com/example/sporthub/data/repository/FavoriteVenueRepository.kt
@@ -1,0 +1,212 @@
+// app/src/main/java/com/example/sporthub/data/repository/FavoriteVenueRepository.kt
+package com.example.sporthub.data.repository
+
+import android.content.Context
+import android.util.Log
+import com.example.sporthub.data.db.FavoriteVenueDao
+import com.example.sporthub.data.db.VenueEntity
+import com.example.sporthub.data.model.Venue
+import com.example.sporthub.utils.ConnectivityHelper
+import com.google.firebase.firestore.FieldValue
+import com.google.firebase.firestore.FirebaseFirestore
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.tasks.await
+import kotlinx.coroutines.withContext
+
+class FavoriteVenueRepository(
+    private val favoriteVenueDao: FavoriteVenueDao,
+    private val context: Context
+) {
+    private val firestore = FirebaseFirestore.getInstance()
+    private val TAG = "FavoriteVenueRepo"
+
+    // Get all favorite venues for a user as a Flow
+    fun getFavoriteVenues(userId: String): Flow<List<Venue>> {
+        return favoriteVenueDao.getAllFavoriteVenues(userId).map { entities ->
+            entities.map { it.toVenue() }
+        }
+    }
+
+    // Add a venue to favorites
+    suspend fun addToFavorites(venue: Venue, userId: String) {
+        withContext(Dispatchers.IO) {
+            // Add to local database
+            val venueEntity = VenueEntity.fromVenue(venue, userId)
+            favoriteVenueDao.insertVenue(venueEntity)
+
+            // Try to update remote if we're online
+            if (ConnectivityHelper.isNetworkAvailable(context)) {
+                try {
+                    updateRemoteFavorites(userId, venue, true)
+                } catch (e: Exception) {
+                    Log.e(TAG, "Error adding to remote favorites: ${e.message}")
+                    // Will be synced later
+                }
+            }
+        }
+    }
+
+    // Remove venue from favorites
+    suspend fun removeFromFavorites(venueId: String, userId: String) {
+        withContext(Dispatchers.IO) {
+            // Update local database
+            favoriteVenueDao.removeFromFavorites(venueId, userId)
+
+            // Try to update remote if we're online
+            if (ConnectivityHelper.isNetworkAvailable(context)) {
+                try {
+                    // First get the venue details
+                    val venue = favoriteVenueDao.getFavoriteVenue(venueId, userId)?.toVenue()
+                    if (venue != null) {
+                        updateRemoteFavorites(userId, venue, false)
+                    }
+                } catch (e: Exception) {
+                    Log.e(TAG, "Error removing from remote favorites: ${e.message}")
+                    // Will be handled during next sync
+                }
+            }
+        }
+    }
+
+    // Check if a venue is favorited
+    suspend fun isVenueFavorite(venueId: String, userId: String): Boolean {
+        return withContext(Dispatchers.IO) {
+            favoriteVenueDao.getFavoriteVenue(venueId, userId) != null
+        }
+    }
+
+    // Sync local changes with remote
+    suspend fun syncWithRemote(userId: String) {
+        if (ConnectivityHelper.isNetworkAvailable(context)) {
+            withContext(Dispatchers.IO) {
+                // Get timestamp of last sync
+                val lastSyncTime = getLastSyncTime(userId)
+
+                // First, push local changes to remote
+                val updatedVenues = favoriteVenueDao.getVenuesUpdatedAfter(lastSyncTime, userId)
+                for (venueEntity in updatedVenues) {
+                    val venue = venueEntity.toVenue()
+                    updateRemoteFavorites(userId, venue, venueEntity.isFavorite)
+                }
+
+                // Then, fetch remote changes and update local
+                fetchRemoteFavorites(userId)
+
+                // Update last sync time
+                saveLastSyncTime(userId, System.currentTimeMillis())
+            }
+        }
+    }
+
+    private suspend fun updateRemoteFavorites(userId: String, venue: Venue, isAdding: Boolean) {
+        withContext(Dispatchers.IO) {
+            val userRef = firestore.collection("users").document(userId)
+
+            try {
+                if (isAdding) {
+                    // Convert venue to Map for Firestore
+                    val venueMap = hashMapOf(
+                        "id" to venue.id,
+                        "name" to venue.name,
+                        "location_name" to venue.locationName,
+                        "image" to venue.image,
+                        "rating" to venue.rating,
+                        "sport" to venue.sport?.let {
+                            hashMapOf(
+                                "id" to it.id,
+                                "name" to it.name,
+                                "logo" to it.logo
+                            )
+                        }
+                    )
+
+                    // Add to venues_liked array
+                    userRef.update("venues_liked", FieldValue.arrayUnion(venueMap)).await()
+                } else {
+                    // For removing, we need to identify the exact object in the array
+                    // First get the user document
+                    val userDoc = userRef.get().await()
+
+                    if (userDoc.exists()) {
+                        // Get venues_liked array
+                        val venuesLiked = userDoc.get("venues_liked") as? List<Map<String, Any>> ?: listOf()
+
+                        // Find matching venue by ID and remove it
+                        val venueToRemove = venuesLiked.find { it["id"] == venue.id }
+                        if (venueToRemove != null) {
+                            userRef.update("venues_liked", FieldValue.arrayRemove(venueToRemove)).await()
+                        } else {
+
+                        }
+                    } else {
+
+                    }
+                }
+            } catch (e: Exception) {
+                Log.e(TAG, "Error updating remote favorites: ${e.message}")
+                throw e
+            }
+        }
+    }
+
+    private suspend fun fetchRemoteFavorites(userId: String) {
+        withContext(Dispatchers.IO) {
+            try {
+                val userDoc = firestore.collection("users").document(userId).get().await()
+
+                if (userDoc.exists()) {
+                    val venuesLikedAny = userDoc.get("venues_liked")
+
+                    if (venuesLikedAny is List<*>) {
+                        val entities = venuesLikedAny.mapNotNull { item ->
+                            if (item is Map<*, *>) {
+                                try {
+                                    VenueEntity(
+                                        id = item["id"] as? String ?: return@mapNotNull null,
+                                        userId = userId,
+                                        name = item["name"] as? String ?: "",
+                                        locationName = item["location_name"] as? String ?: "",
+                                        image = item["image"] as? String ?: "",
+                                        rating = (item["rating"] as? Number)?.toDouble() ?: 0.0,
+                                        sportId = (item["sport"] as? Map<*, *>)?.get("id") as? String,
+                                        sportName = (item["sport"] as? Map<*, *>)?.get("name") as? String,
+                                        sportLogo = (item["sport"] as? Map<*, *>)?.get("logo") as? String
+                                    )
+                                } catch (e: Exception) {
+                                    Log.e(TAG, "Error parsing venue: ${e.message}")
+                                    null
+                                }
+                            } else null
+                        }
+
+                        // Update local database with remote venues
+                        if (entities.isNotEmpty()) {
+                            favoriteVenueDao.insertVenues(entities)
+                        } else {
+
+                        }
+                    } else {
+
+                    }
+                } else {
+
+                }
+            } catch (e: Exception) {
+                Log.e(TAG, "Error fetching remote favorites: ${e.message}")
+            }
+        }
+    }
+
+    // Helper methods for last sync time
+    private fun getLastSyncTime(userId: String): Long {
+        val prefs = context.getSharedPreferences("favorite_sync_prefs", Context.MODE_PRIVATE)
+        return prefs.getLong("${userId}_last_sync", 0)
+    }
+
+    private fun saveLastSyncTime(userId: String, time: Long) {
+        val prefs = context.getSharedPreferences("favorite_sync_prefs", Context.MODE_PRIVATE)
+        prefs.edit().putLong("${userId}_last_sync", time).apply()
+    }
+}

--- a/app/src/main/java/com/example/sporthub/ui/createBooking/CreateBookingFragment.kt
+++ b/app/src/main/java/com/example/sporthub/ui/createBooking/CreateBookingFragment.kt
@@ -19,6 +19,7 @@ import androidx.navigation.fragment.navArgs
 import com.example.sporthub.R
 import com.example.sporthub.data.model.Venue
 import com.example.sporthub.databinding.FragmentCreateBookingBinding
+import com.example.sporthub.utils.BookingTimeTracker
 import com.example.sporthub.viewmodel.CreateBookingViewModel
 import com.example.sporthub.viewmodel.SharedUserViewModel
 import java.time.*
@@ -75,6 +76,8 @@ class CreateBookingFragment : Fragment() {
         inflater: LayoutInflater, container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View {
+        BookingTimeTracker.startTimer()
+
         binding = FragmentCreateBookingBinding.inflate(inflater, container, false)
         venue1 = args.venue
 
@@ -230,7 +233,13 @@ class CreateBookingFragment : Fragment() {
 
     private fun observeViewModel() {
         viewModel.reservationResult.observe(viewLifecycleOwner) { success ->
-            val msg = if (success) "Reservation created successfully" else "Failed to create reservation"
+            val msg = if (success) {
+
+                BookingTimeTracker.stopTimerAndSave(requireContext())
+
+                "Reservation created successfully"
+
+            } else "Failed to create reservation"
             Toast.makeText(context, msg, Toast.LENGTH_LONG).show()
         }
         viewModel.bookingCreated.observe(viewLifecycleOwner) { created ->
@@ -274,6 +283,10 @@ class CreateBookingFragment : Fragment() {
 
     override fun onDestroyView() {
         super.onDestroyView()
+        // In case the user cancels without completing the booking
+        if (viewModel.bookingCreated.value != true) {
+            BookingTimeTracker.stopTimerAndSave(requireContext())
+        }
         handler.removeCallbacks(updateTimeSlotsRunnable)
     }
 }

--- a/app/src/main/java/com/example/sporthub/ui/profile/ProfileFragment.kt
+++ b/app/src/main/java/com/example/sporthub/ui/profile/ProfileFragment.kt
@@ -3,6 +3,10 @@ package com.example.sporthub.ui.profile
 import android.content.Context
 import android.content.Intent
 import android.graphics.drawable.Drawable
+import android.net.ConnectivityManager
+import android.net.Network
+import android.net.NetworkRequest
+import android.os.Build
 import android.os.Bundle
 import android.os.Handler
 import android.os.Looper
@@ -19,6 +23,7 @@ import androidx.appcompat.widget.SwitchCompat
 import androidx.core.content.ContextCompat
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
+import androidx.fragment.app.viewModels
 import androidx.lifecycle.ViewModelProvider
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
@@ -26,6 +31,7 @@ import com.example.sporthub.R
 import com.example.sporthub.data.model.Sport
 import com.example.sporthub.data.model.User
 import com.example.sporthub.ui.login.SignInActivity
+import com.example.sporthub.utils.ConnectivityHelper
 import com.example.sporthub.viewmodel.SharedUserViewModel
 import com.google.android.gms.auth.api.signin.GoogleSignIn
 import com.google.android.gms.auth.api.signin.GoogleSignInOptions
@@ -34,12 +40,14 @@ import com.example.sporthub.ui.profile.edit.EditNameActivity
 import com.example.sporthub.ui.profile.edit.EditGenderActivity
 import com.example.sporthub.ui.profile.edit.EditBirthDateActivity
 import com.example.sporthub.ui.profile.edit.EditSportsActivity
+import com.example.sporthub.viewmodel.FavoriteVenuesViewModel
 import com.google.android.material.snackbar.Snackbar
 
 class ProfileFragment : Fragment() {
 
     private lateinit var viewModel: ProfileViewModel
     private val sharedUserViewModel: SharedUserViewModel by activityViewModels()
+    private val favoriteVenuesViewModel: FavoriteVenuesViewModel by viewModels()
 
     private lateinit var profileName: TextView
     private lateinit var genderValue: TextView
@@ -56,6 +64,9 @@ class ProfileFragment : Fragment() {
     private lateinit var themeSwitch: SwitchCompat
 
     private lateinit var favoriteVenueAdapter: FavoriteVenueAdapter
+
+    // Network callback for syncing when connection is restored
+    private var networkCallback: ConnectivityManager.NetworkCallback? = null
 
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
@@ -90,6 +101,11 @@ class ProfileFragment : Fragment() {
 
         // Load data
         viewModel.loadUserData()
+
+        // Sync with remote if online
+        if (ConnectivityHelper.isNetworkAvailable(requireContext())) {
+            favoriteVenuesViewModel.syncWithRemote()
+        }
     }
 
     private fun initViews(view: View) {
@@ -129,7 +145,8 @@ class ProfileFragment : Fragment() {
             updateUI(user)
         }
 
-        viewModel.favoriteVenues.observe(viewLifecycleOwner) { venues ->
+        // Observe favorite venues from Room database instead of Firebase
+        favoriteVenuesViewModel.favoriteVenues.observe(viewLifecycleOwner) { venues ->
             favoriteVenueAdapter.submitList(venues)
 
             // Show or hide the no venues message
@@ -194,7 +211,6 @@ class ProfileFragment : Fragment() {
             }
         }
     }
-
 
     private fun preloadThemeResources() {
         // This method preloads essential UI resources for both themes
@@ -280,17 +296,8 @@ class ProfileFragment : Fragment() {
         // Update favorite sports
         updateFavoriteSports(user.sportsLiked)
 
-        // Display favorite venues
-        favoriteVenueAdapter.submitList(user.venuesLiked)
-
-        // Show or hide the no venues message
-        if (user.venuesLiked.isNullOrEmpty()) {
-            noFavoriteVenuesText.visibility = View.VISIBLE
-            favoriteVenuesRecyclerView.visibility = View.GONE
-        } else {
-            noFavoriteVenuesText.visibility = View.GONE
-            favoriteVenuesRecyclerView.visibility = View.VISIBLE
-        }
+        // We don't need to update favorite venues here anymore since they're observed from Room
+        // This ensures offline availability
     }
 
     private fun updateFavoriteSports(sports: List<Sport>) {
@@ -381,6 +388,40 @@ class ProfileFragment : Fragment() {
         }
     }
 
+    override fun onStart() {
+        super.onStart()
+
+        // Set up network callback to sync when connectivity is restored
+        networkCallback = object : ConnectivityManager.NetworkCallback() {
+            override fun onAvailable(network: Network) {
+                // Sync with remote when connection is restored
+                favoriteVenuesViewModel.syncWithRemote()
+            }
+        }
+
+        // Register the network callback
+        val connectivityManager =
+            requireContext().getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+            connectivityManager.registerDefaultNetworkCallback(networkCallback!!)
+        } else {
+            val request = NetworkRequest.Builder().build()
+            connectivityManager.registerNetworkCallback(request, networkCallback!!)
+        }
+    }
+
+    override fun onStop() {
+        super.onStop()
+
+        // Unregister the network callback to prevent leaks
+        networkCallback?.let {
+            val connectivityManager =
+                requireContext().getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
+            connectivityManager.unregisterNetworkCallback(it)
+        }
+    }
+
     override fun onResume() {
         super.onResume()
 
@@ -400,5 +441,4 @@ class ProfileFragment : Fragment() {
             Log.d("ProfileFragment", "User data already loaded, skipping reload")
         }
     }
-
 }

--- a/app/src/main/java/com/example/sporthub/utils/BookingTimeTracker.kt
+++ b/app/src/main/java/com/example/sporthub/utils/BookingTimeTracker.kt
@@ -1,0 +1,103 @@
+package com.example.sporthub.utils
+
+import android.content.Context
+import android.util.Log
+import com.google.firebase.firestore.FirebaseFirestore
+import com.google.firebase.firestore.FieldValue
+import java.util.concurrent.TimeUnit
+
+object BookingTimeTracker {
+    private const val TAG = "BookingTimeTracker"
+
+    // Firebase path for booking creation analytics
+    private const val ANALYTICS_PATH = "analytics/screen_time/all/Create Booking View"
+
+    // Start time of the booking process
+    private var startTimeMillis: Long = 0
+
+    // Flag to track if timer is running
+    private var isTimerRunning = false
+
+    /**
+     * Start the booking timer when the user begins the booking creation process
+     */
+    fun startTimer() {
+        if (!isTimerRunning) {
+            startTimeMillis = System.currentTimeMillis()
+            isTimerRunning = true
+            Log.d(TAG, "Booking creation timer started")
+        }
+    }
+
+    /**
+     * Stop the timer and record the time spent in Firebase
+     */
+    fun stopTimerAndSave(context: Context? = null) {
+        if (isTimerRunning) {
+            val endTimeMillis = System.currentTimeMillis()
+            val durationSeconds = TimeUnit.MILLISECONDS.toSeconds(endTimeMillis - startTimeMillis)
+
+            // Check connectivity if context is provided
+            if (context != null && !ConnectivityHelper.isNetworkAvailable(context)) {
+                Log.w(TAG, "No internet connection, cannot save booking creation time")
+                isTimerRunning = false
+                return
+            }
+
+            saveBookingCreationTime(durationSeconds)
+            isTimerRunning = false
+            Log.d(TAG, "Booking creation completed in $durationSeconds seconds")
+        }
+    }
+
+    /**
+     * Save the booking creation time to Firebase analytics
+     */
+    private fun saveBookingCreationTime(durationSeconds: Long) {
+        val db = FirebaseFirestore.getInstance()
+        val analyticsRef = db.document(ANALYTICS_PATH)
+
+        // Update the average time and increment visit count
+        analyticsRef.get().addOnSuccessListener { document ->
+            if (document.exists()) {
+                // Existing document - update average and count
+                val currentAverage = document.getDouble("average_time") ?: 0.0
+                val currentCount = document.getLong("visit_count") ?: 0L
+
+                // Calculate new average
+                val newCount = currentCount + 1
+                val newAverage = ((currentAverage * currentCount) + durationSeconds) / newCount
+
+                // Update with new values
+                analyticsRef.update(
+                    mapOf(
+                        "average_time" to newAverage,
+                        "visit_count" to newCount,
+                        "last_updated" to FieldValue.serverTimestamp()
+                    )
+                ).addOnSuccessListener {
+                    Log.d(TAG, "Booking creation analytics updated: avg=$newAverage, count=$newCount")
+                }.addOnFailureListener { e ->
+                    Log.e(TAG, "Error updating booking creation analytics", e)
+                }
+            } else {
+                // First booking creation - create document
+                val data = hashMapOf(
+                    "average_time" to durationSeconds.toDouble(),
+                    "visit_count" to 1L,
+                    "last_updated" to FieldValue.serverTimestamp()
+                )
+
+                analyticsRef.set(data)
+                    .addOnSuccessListener {
+                        Log.d(TAG, "First booking creation analytics saved: time=$durationSeconds")
+                    }
+                    .addOnFailureListener { e ->
+                        Log.e(TAG, "Error saving first booking creation analytics", e)
+                    }
+            }
+        }.addOnFailureListener { e ->
+            Log.e(TAG, "Error reading booking creation analytics", e)
+        }
+    }
+}

--- a/app/src/main/java/com/example/sporthub/viewmodel/FavoriteVenuesViewModel.kt
+++ b/app/src/main/java/com/example/sporthub/viewmodel/FavoriteVenuesViewModel.kt
@@ -1,0 +1,68 @@
+package com.example.sporthub.viewmodel
+
+import android.app.Application
+import androidx.lifecycle.AndroidViewModel
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.asLiveData
+import androidx.lifecycle.viewModelScope
+import com.example.sporthub.data.db.AppDatabase
+import com.example.sporthub.data.model.Venue
+import com.example.sporthub.data.repository.FavoriteVenueRepository
+import com.google.firebase.auth.FirebaseAuth
+import kotlinx.coroutines.launch
+
+class FavoriteVenuesViewModel(application: Application) : AndroidViewModel(application) {
+
+    private val repository: FavoriteVenueRepository
+    private val userId: String? = FirebaseAuth.getInstance().currentUser?.uid
+
+    // LiveData for favorite venues
+    val favoriteVenues: LiveData<List<Venue>>
+
+    init {
+        val database = AppDatabase.getDatabase(application)
+        repository = FavoriteVenueRepository(database.favoriteVenueDao(), application)
+
+        // Initialize favorite venues LiveData
+        favoriteVenues = if (userId != null) {
+            repository.getFavoriteVenues(userId).asLiveData()
+        } else {
+            MutableLiveData(emptyList())
+        }
+    }
+
+    // Add venue to favorites
+    fun addToFavorites(venue: Venue) {
+        userId?.let { id ->
+            viewModelScope.launch {
+                repository.addToFavorites(venue, id)
+            }
+        }
+    }
+
+    // Remove venue from favorites
+    fun removeFromFavorites(venueId: String) {
+        userId?.let { id ->
+            viewModelScope.launch {
+                repository.removeFromFavorites(venueId, id)
+            }
+        }
+    }
+
+    // Check if venue is in favorites
+    suspend fun isVenueFavorite(venueId: String): Boolean {
+        return userId?.let { id ->
+            repository.isVenueFavorite(venueId, id)
+        } ?: false
+    }
+
+    // Sync with remote database
+    fun syncWithRemote() {
+        userId?.let { id ->
+            viewModelScope.launch {
+                repository.syncWithRemote(id)
+            }
+        }
+    }
+}

--- a/app/src/main/res/layout/fragment_create_booking.xml
+++ b/app/src/main/res/layout/fragment_create_booking.xml
@@ -121,12 +121,12 @@
                         android:id="@+id/playerCountSpinner"
                         android:layout_width="match_parent"
                         android:layout_height="48dp"
-                        android:minHeight="48dp"
                         android:layout_marginTop="8dp"
+                        android:background="@drawable/bg_spinner_touch_area"
+                        android:minHeight="48dp"
                         android:paddingStart="16dp"
                         android:paddingEnd="16dp"
-                        android:textColor="#000"
-                        android:background="@drawable/bg_spinner_touch_area" />
+                        android:textColor="@android:color/black" />
                 </LinearLayout>
 
             </LinearLayout>


### PR DESCRIPTION
This pull request introduces several significant updates, including migrating to a more modern Kotlin setup, adding a Room database for local data persistence, and enhancing the booking flow with a time-tracking feature. Below is a breakdown of the most important changes grouped by theme:

### Build and Dependency Updates
* Updated Kotlin version from `1.8.0` to `1.9.24` in `.idea/kotlinc.xml` and replaced KSP with KAPT in `app/build.gradle.kts` for annotation processing. [[1]](diffhunk://#diff-829d52b273145b9cea58047cbe1856e097e7daf89ea933f1550a7c36ee2ebeecL4-R4) [[2]](diffhunk://#diff-8cff73265af19c059547b76aca8882cbaa3209291406f52df1dafbbc78e80c46L6-R9)
* Centralized dependency versions (e.g., `coroutinesVersion`, `roomVersion`) and ensured consistent usage across the project.

### Room Database Integration
* Added `AppDatabase` with a `FavoriteVenueDao` to manage favorite venues locally. Includes type converters for `Date` and `Boolean` compatibility. [[1]](diffhunk://#diff-25d34e563c829aa2e7ef9f2f0d7f6f1550cd23a75699c02927d481657ec73db9R1-R33) [[2]](diffhunk://#diff-c3f075f77defe1d09c62e1543f7adc7646720993a904f7618f6aa12a48dfd416R1-R43) [[3]](diffhunk://#diff-69429144f1f424138d1c5c88b9408301b17e8ac1dc75a57672482a8839b27cf7R1-R54)
* Introduced `VenueEntity` to represent favorite venues in the database, including conversion methods to/from the `Venue` model.

### Repository Enhancements
* Created `FavoriteVenueRepository` to handle local and remote synchronization of favorite venues, including methods for adding, removing, and syncing venues.

### Booking Flow Improvements
* Integrated `BookingTimeTracker` in `CreateBookingFragment` to track and save the time spent during the booking process. [[1]](diffhunk://#diff-f3654b95b89462f67f5b5a3516f469de6443d03a59394eec149e3a3e62da52b3R22) [[2]](diffhunk://#diff-f3654b95b89462f67f5b5a3516f469de6443d03a59394eec149e3a3e62da52b3R79-R80) [[3]](diffhunk://#diff-f3654b95b89462f67f5b5a3516f469de6443d03a59394eec149e3a3e62da52b3L233-R242) [[4]](diffhunk://#diff-f3654b95b89462f67f5b5a3516f469de6443d03a59394eec149e3a3e62da52b3R286-R289)