### PR TITLE
feat: Measure Loading time for Profile View.

### DIFF
--- a/app/src/main/java/com/example/sporthub/ui/profile/ProfileFragment.kt
+++ b/app/src/main/java/com/example/sporthub/ui/profile/ProfileFragment.kt
@@ -44,6 +44,7 @@ import com.example.sporthub.ui.profile.edit.EditGenderActivity
 import com.example.sporthub.ui.profile.edit.EditBirthDateActivity
 import com.example.sporthub.ui.profile.edit.EditSportsActivity
 import com.example.sporthub.viewmodel.FavoriteVenuesViewModel
+import com.example.sporthub.utils.LoadingTimeTracker
 import com.google.android.material.snackbar.Snackbar
 
 class ProfileFragment : Fragment() {
@@ -78,6 +79,9 @@ class ProfileFragment : Fragment() {
         inflater: LayoutInflater, container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View {
+        // Start the loading time tracker
+        LoadingTimeTracker.start()
+
         // Use the updated layout
         return inflater.inflate(R.layout.fragment_profile, container, false)
     }
@@ -291,6 +295,9 @@ class ProfileFragment : Fragment() {
             if (user != null) {
                 Log.d("ProfileFragment", "User data from profile viewmodel: ${user.name}")
                 updateUI(user)
+
+                // Stop the loading time tracker after the UI is updated
+                LoadingTimeTracker.stopAndRecord("Profile View", requireContext())
             }
         }
 


### PR DESCRIPTION
This pull request introduces a loading time tracking feature to the `ProfileFragment` in the `SportHub` app. The changes involve integrating the `LoadingTimeTracker` utility to measure and record the time taken to load the profile view.

### Loading time tracking:

* **Utility import**: Added `LoadingTimeTracker` import to enable tracking of loading times. (`app/src/main/java/com/example/sporthub/ui/profile/ProfileFragment.kt`)
* **Start tracking**: Initiated the loading time tracker at the beginning of the `onCreateView` method to measure the time taken to load the profile layout. (`app/src/main/java/com/example/sporthub/ui/profile/ProfileFragment.kt`)
* **Stop and record tracking**: Stopped the loading time tracker and recorded the results after the UI is updated with user data. (`app/src/main/java/com/example/sporthub/ui/profile/ProfileFragment.kt`)