### PR TITLE
Feat/110 caching for calendar view

### DIFF
--- a/app/src/main/java/com/example/sporthub/viewmodel/BookingsViewModel.kt
+++ b/app/src/main/java/com/example/sporthub/viewmodel/BookingsViewModel.kt
@@ -1,6 +1,8 @@
 package com.example.sporthub.viewmodel
 
 import android.app.Application
+import android.content.Context
+import android.content.SharedPreferences
 import android.util.Log
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.LiveData
@@ -17,6 +19,15 @@ import java.util.Calendar
 import java.util.Date
 
 class BookingsViewModel(application: Application) : AndroidViewModel(application) {
+
+    private val sharedPreferences: SharedPreferences = application.getSharedPreferences(
+        "bookings_preferences", // Name for your preferences file
+        Context.MODE_PRIVATE
+    )
+    companion object {
+        private const val KEY_LAST_DATE = "key_last_date"
+    }
+
 
     private val db = FirebaseFirestore.getInstance()
     private var bookingsListener: ListenerRegistration? = null
@@ -36,8 +47,18 @@ class BookingsViewModel(application: Application) : AndroidViewModel(application
     private var allUserBookings: List<Booking> = emptyList()
 
     init {
-        _selectedDate.value = Calendar.getInstance().time
-        // This will now check for network first
+        // Read the last saved date directly from SharedPreferences
+        val lastDateMillis = sharedPreferences.getLong(KEY_LAST_DATE, -1L)
+
+        _selectedDate.value = if (lastDateMillis != -1L) {
+            // If a date was saved, use it
+            Date(lastDateMillis)
+        } else {
+            // Otherwise, default to today
+            Calendar.getInstance().time
+        }
+
+        // Now that the date is set, fetch bookings
         listenForUserBookings()
     }
 
@@ -47,6 +68,11 @@ class BookingsViewModel(application: Application) : AndroidViewModel(application
 
     fun setSelectedDate(date: Date) {
         _selectedDate.value = date
+        // Save the new date to SharedPreferences using the classic apply() method
+        sharedPreferences.edit()
+            .putLong(KEY_LAST_DATE, date.time)
+            .apply()
+
         filterBookingsForSelectedDate()
     }
 

--- a/app/src/main/java/com/example/sporthub/viewmodel/BookingsViewModel.kt
+++ b/app/src/main/java/com/example/sporthub/viewmodel/BookingsViewModel.kt
@@ -4,29 +4,39 @@ import android.app.Application
 import android.content.Context
 import android.content.SharedPreferences
 import android.util.Log
+import androidx.core.content.edit
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import com.example.sporthub.data.model.Booking
 import com.example.sporthub.data.model.Sport
 import com.example.sporthub.data.model.Venue
-import com.example.sporthub.utils.ConnectivityHelper // Import your helper
+import com.example.sporthub.utils.ConnectivityHelper
+import com.example.sporthub.utils.LRUCache // Import your LRUCache
 import com.google.firebase.Timestamp
 import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.firestore.FirebaseFirestore
 import com.google.firebase.firestore.ListenerRegistration
+import java.text.SimpleDateFormat
 import java.util.Calendar
 import java.util.Date
+import java.util.Locale
 
 class BookingsViewModel(application: Application) : AndroidViewModel(application) {
 
     private val sharedPreferences: SharedPreferences = application.getSharedPreferences(
-        "bookings_preferences", // Name for your preferences file
+        "bookings_preferences",
         Context.MODE_PRIVATE
     )
     companion object {
         private const val KEY_LAST_DATE = "key_last_date"
     }
+
+    // Instantiate the LRUCache to hold daily bookings.
+    private val bookingsCache = LRUCache<String, List<Booking>>(5) // Caches up to 5 days
+    // A formatter to create consistent keys from dates (e.g., "2025-05-28")
+    private val cacheKeyFormatter = SimpleDateFormat("yyyy-MM-dd", Locale.getDefault())
+    // --- END OF NEW CACHING IMPLEMENTATION ---
 
 
     private val db = FirebaseFirestore.getInstance()
@@ -47,18 +57,9 @@ class BookingsViewModel(application: Application) : AndroidViewModel(application
     private var allUserBookings: List<Booking> = emptyList()
 
     init {
-        // Read the last saved date directly from SharedPreferences
+        // This logic is unchanged
         val lastDateMillis = sharedPreferences.getLong(KEY_LAST_DATE, -1L)
-
-        _selectedDate.value = if (lastDateMillis != -1L) {
-            // If a date was saved, use it
-            Date(lastDateMillis)
-        } else {
-            // Otherwise, default to today
-            Calendar.getInstance().time
-        }
-
-        // Now that the date is set, fetch bookings
+        _selectedDate.value = if (lastDateMillis != -1L) Date(lastDateMillis) else Calendar.getInstance().time
         listenForUserBookings()
     }
 
@@ -66,26 +67,31 @@ class BookingsViewModel(application: Application) : AndroidViewModel(application
         listenForUserBookings()
     }
 
+
     fun setSelectedDate(date: Date) {
         _selectedDate.value = date
-        // Save the new date to SharedPreferences using the classic apply() method
-        sharedPreferences.edit()
-            .putLong(KEY_LAST_DATE, date.time)
-            .apply()
+        sharedPreferences.edit().putLong(KEY_LAST_DATE, date.time).apply()
 
-        filterBookingsForSelectedDate()
+        // Decide what to do based on connectivity
+        if (isNetworkAvailable.value == true) {
+            // If online, filter the master list from Firestore which will also update the cache
+            filterBookingsForSelectedDate()
+        } else {
+            // If offline, try to load the newly selected date directly from the cache
+            loadFromCache()
+        }
     }
 
-    private fun listenForUserBookings() {
 
+    private fun listenForUserBookings() {
         if (!ConnectivityHelper.isNetworkAvailable(getApplication())) {
             _isNetworkAvailable.postValue(false)
-            // Post empty values to clear screen and stop loading indicators
-            _bookingsForSelectedDate.postValue(emptyList())
             _isLoading.postValue(false)
-            return // Stop here if no network
+            // When offline, immediately attempt to load data from the cache
+            loadFromCache()
+            return
         }
-        _isNetworkAvailable.postValue(true) // Network is available
+        _isNetworkAvailable.postValue(true)
 
         val userId = FirebaseAuth.getInstance().currentUser?.uid
         if (userId == null) {
@@ -120,7 +126,6 @@ class BookingsViewModel(application: Application) : AndroidViewModel(application
                                 sport = sport
                             )
                         }
-
                         Booking(
                             id = bookingMap["id"] as? String ?: "",
                             startTime = bookingMap["start_time"] as? Timestamp,
@@ -143,26 +148,50 @@ class BookingsViewModel(application: Application) : AndroidViewModel(application
         }
     }
 
-    private fun filterBookingsForSelectedDate() {
-        val calendar = Calendar.getInstance()
-        val currentDate = _selectedDate.value ?: return
-        calendar.time = currentDate
 
+    private fun filterBookingsForSelectedDate() {
+        val currentDate = _selectedDate.value ?: return
+        val calendar = Calendar.getInstance().apply { time = currentDate }
         val currentYear = calendar.get(Calendar.YEAR)
         val currentMonth = calendar.get(Calendar.MONTH)
         val currentDay = calendar.get(Calendar.DAY_OF_MONTH)
 
         val filtered = allUserBookings.filter { booking ->
             booking.startTime?.toDate()?.let { bookingDate ->
-                val bookingCal = Calendar.getInstance()
-                bookingCal.time = bookingDate
+                val bookingCal = Calendar.getInstance().apply { time = bookingDate }
                 bookingCal.get(Calendar.YEAR) == currentYear &&
                         bookingCal.get(Calendar.MONTH) == currentMonth &&
                         bookingCal.get(Calendar.DAY_OF_MONTH) == currentDay
             } ?: false
         }
+
+        // Save the filtered list to our cache
+        val cacheKey = cacheKeyFormatter.format(currentDate)
+        bookingsCache[cacheKey] = filtered
+        Log.d("BookingsViewModel", "Saved ${filtered.size} bookings to cache for key: $cacheKey")
+
         _bookingsForSelectedDate.postValue(filtered)
         _isLoading.postValue(false)
+    }
+
+
+    private fun loadFromCache() {
+        val currentDate = _selectedDate.value ?: return
+        val cacheKey = cacheKeyFormatter.format(currentDate)
+
+        // cachedBookings is of type List<Booking>? (nullable)
+        val cachedBookings = bookingsCache[cacheKey]
+
+        // This 'if' check is the key to solving the error
+        if (cachedBookings != null) {
+            // Inside this block, Kotlin knows cachedBookings is NOT null
+            _bookingsForSelectedDate.postValue(cachedBookings) // This is now safe
+            Log.d("BookingsViewModel", "Loaded ${cachedBookings.size} bookings from cache for key: $cacheKey")
+        } else {
+            // If the cache returned null, we post an empty list instead
+            _bookingsForSelectedDate.postValue(emptyList())
+            Log.d("BookingsViewModel", "No bookings found in cache for key: $cacheKey")
+        }
     }
 
     override fun onCleared() {

--- a/app/src/main/java/com/example/sporthub/viewmodel/BookingsViewModel.kt
+++ b/app/src/main/java/com/example/sporthub/viewmodel/BookingsViewModel.kt
@@ -8,15 +8,19 @@ import androidx.core.content.edit
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.viewModelScope
 import com.example.sporthub.data.model.Booking
 import com.example.sporthub.data.model.Sport
 import com.example.sporthub.data.model.Venue
 import com.example.sporthub.utils.ConnectivityHelper
-import com.example.sporthub.utils.LRUCache // Import your LRUCache
+import com.example.sporthub.utils.LRUCache
 import com.google.firebase.Timestamp
 import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.firestore.FirebaseFirestore
 import com.google.firebase.firestore.ListenerRegistration
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import java.text.SimpleDateFormat
 import java.util.Calendar
 import java.util.Date
@@ -32,12 +36,8 @@ class BookingsViewModel(application: Application) : AndroidViewModel(application
         private const val KEY_LAST_DATE = "key_last_date"
     }
 
-    // Instantiate the LRUCache to hold daily bookings.
-    private val bookingsCache = LRUCache<String, List<Booking>>(5) // Caches up to 5 days
-    // A formatter to create consistent keys from dates (e.g., "2025-05-28")
+    private val bookingsCache = LRUCache<String, List<Booking>>(5)
     private val cacheKeyFormatter = SimpleDateFormat("yyyy-MM-dd", Locale.getDefault())
-    // --- END OF NEW CACHING IMPLEMENTATION ---
-
 
     private val db = FirebaseFirestore.getInstance()
     private var bookingsListener: ListenerRegistration? = null
@@ -57,140 +57,131 @@ class BookingsViewModel(application: Application) : AndroidViewModel(application
     private var allUserBookings: List<Booking> = emptyList()
 
     init {
-        // This logic is unchanged
-        val lastDateMillis = sharedPreferences.getLong(KEY_LAST_DATE, -1L)
-        _selectedDate.value = if (lastDateMillis != -1L) Date(lastDateMillis) else Calendar.getInstance().time
-        listenForUserBookings()
+        viewModelScope.launch {
+            // Use IO dispatcher for SharedPreferences read
+            val initialDate = withContext(Dispatchers.IO) {
+                val lastDateMillis = sharedPreferences.getLong(KEY_LAST_DATE, -1L)
+                if (lastDateMillis != -1L) Date(lastDateMillis) else Calendar.getInstance().time
+            }
+            // Update LiveData on the Main thread
+            _selectedDate.value = initialDate
+            listenForUserBookings()
+        }
     }
 
     fun onRetry() {
         listenForUserBookings()
     }
 
-
     fun setSelectedDate(date: Date) {
         _selectedDate.value = date
-        sharedPreferences.edit().putLong(KEY_LAST_DATE, date.time).apply()
+        // Launch a coroutine for the SharedPreferences I/O operation
+        viewModelScope.launch(Dispatchers.IO) {
+            sharedPreferences.edit().putLong(KEY_LAST_DATE, date.time).apply()
+        }
 
-        // Decide what to do based on connectivity
         if (isNetworkAvailable.value == true) {
-            // If online, filter the master list from Firestore which will also update the cache
-            filterBookingsForSelectedDate()
+            viewModelScope.launch { filterBookingsForSelectedDate() }
         } else {
-            // If offline, try to load the newly selected date directly from the cache
-            loadFromCache()
+            viewModelScope.launch { loadFromCache() }
         }
     }
-
 
     private fun listenForUserBookings() {
         if (!ConnectivityHelper.isNetworkAvailable(getApplication())) {
             _isNetworkAvailable.postValue(false)
             _isLoading.postValue(false)
-            // When offline, immediately attempt to load data from the cache
-            loadFromCache()
+            viewModelScope.launch { loadFromCache() }
             return
         }
         _isNetworkAvailable.postValue(true)
-
         val userId = FirebaseAuth.getInstance().currentUser?.uid
         if (userId == null) {
-            Log.e("BookingsViewModel", "User not logged in.")
-            return
+            Log.e("BookingsViewModel", "User not logged in."); return
         }
 
         _isLoading.value = true
         val userDocRef = db.collection("users").document(userId)
 
         bookingsListener = userDocRef.addSnapshotListener { snapshot, error ->
-            if (error != null) {
-                Log.e("BookingsViewModel", "Listen failed.", error)
-                allUserBookings = emptyList()
-                filterBookingsForSelectedDate()
-                return@addSnapshotListener
-            }
+            viewModelScope.launch {
+                if (error != null) {
+                    Log.e("BookingsViewModel", "Listen failed.", error)
+                    allUserBookings = emptyList()
+                    filterBookingsForSelectedDate()
+                    return@launch
+                }
 
-            if (snapshot != null && snapshot.exists()) {
-                val bookingsRaw = snapshot["bookings"] as? List<Map<String, Any>>
-                val bookingsParsed = bookingsRaw?.mapNotNull { bookingMap ->
-                    try {
-                        val venueMap = bookingMap["venue"] as? Map<String, Any>
-                        val venue = venueMap?.let {
-                            val sportMap = it["sport"] as? Map<String, Any>
-                            val sport = sportMap?.let { sp -> Sport(id = sp["id"] as? String ?: "", name = sp["name"] as? String ?: "") }
-                            Venue(
-                                id = it["id"] as? String ?: "",
-                                name = it["name"] as? String ?: "",
-                                locationName = it["location_name"] as? String ?: "",
-                                image = it["image"] as? String ?: "",
-                                sport = sport
-                            )
-                        }
-                        Booking(
-                            id = bookingMap["id"] as? String ?: "",
-                            startTime = bookingMap["start_time"] as? Timestamp,
-                            endTime = bookingMap["end_time"] as? Timestamp,
-                            maxUsers = (bookingMap["max_users"] as? Long)?.toInt() ?: 0,
-                            users = bookingMap["users"] as? List<String> ?: emptyList(),
-                            venue = venue
-                        )
-                    } catch (e: Exception) {
-                        Log.e("BookingsViewModel", "Failed to parse a booking.", e)
-                        null
+                // Use IO dispatcher to move parsing off the main thread
+                val parsedList = withContext(Dispatchers.IO) {
+                    if (snapshot != null && snapshot.exists()) {
+                        val bookingsRaw = snapshot["bookings"] as? List<Map<String, Any>>
+                        bookingsRaw?.mapNotNull { bookingMap ->
+                            try {
+                                val venueMap = bookingMap["venue"] as? Map<String, Any>
+                                val venue = venueMap?.let {
+                                    val sportMap = it["sport"] as? Map<String, Any>
+                                    val sport = sportMap?.let { sp -> Sport(id = sp["id"] as? String ?: "", name = sp["name"] as? String ?: "") }
+                                    Venue(id = it["id"] as? String ?: "", name = it["name"] as? String ?: "", locationName = it["location_name"] as? String ?: "", image = it["image"] as? String ?: "", sport = sport)
+                                }
+                                Booking(id = bookingMap["id"] as? String ?: "", startTime = bookingMap["start_time"] as? Timestamp, endTime = bookingMap["end_time"] as? Timestamp, maxUsers = (bookingMap["max_users"] as? Long)?.toInt() ?: 0, users = bookingMap["users"] as? List<String> ?: emptyList(), venue = venue)
+                            } catch (e: Exception) {
+                                Log.e("BookingsViewModel", "Failed to parse a booking.", e); null
+                            }
+                        } ?: emptyList()
+                    } else {
+                        emptyList()
                     }
-                } ?: emptyList()
-
-                allUserBookings = bookingsParsed
-            } else {
-                allUserBookings = emptyList()
+                }
+                allUserBookings = parsedList
+                filterBookingsForSelectedDate()
             }
-            filterBookingsForSelectedDate()
         }
     }
 
-
-    private fun filterBookingsForSelectedDate() {
+    private suspend fun filterBookingsForSelectedDate() {
         val currentDate = _selectedDate.value ?: return
-        val calendar = Calendar.getInstance().apply { time = currentDate }
-        val currentYear = calendar.get(Calendar.YEAR)
-        val currentMonth = calendar.get(Calendar.MONTH)
-        val currentDay = calendar.get(Calendar.DAY_OF_MONTH)
 
-        val filtered = allUserBookings.filter { booking ->
-            booking.startTime?.toDate()?.let { bookingDate ->
-                val bookingCal = Calendar.getInstance().apply { time = bookingDate }
-                bookingCal.get(Calendar.YEAR) == currentYear &&
-                        bookingCal.get(Calendar.MONTH) == currentMonth &&
-                        bookingCal.get(Calendar.DAY_OF_MONTH) == currentDay
-            } ?: false
+        // Use IO dispatcher to move filtering off the main thread
+        val filtered = withContext(Dispatchers.IO) {
+            val calendar = Calendar.getInstance().apply { time = currentDate }
+            val currentYear = calendar.get(Calendar.YEAR)
+            val currentMonth = calendar.get(Calendar.MONTH)
+            val currentDay = calendar.get(Calendar.DAY_OF_MONTH)
+
+            val filteredList = allUserBookings.filter { booking ->
+                booking.startTime?.toDate()?.let { bookingDate ->
+                    val bookingCal = Calendar.getInstance().apply { time = bookingDate }
+                    bookingCal.get(Calendar.YEAR) == currentYear &&
+                            bookingCal.get(Calendar.MONTH) == currentMonth &&
+                            bookingCal.get(Calendar.DAY_OF_MONTH) == currentDay
+                } ?: false
+            }
+
+            val cacheKey = cacheKeyFormatter.format(currentDate)
+            bookingsCache[cacheKey] = filteredList
+            Log.d("BookingsViewModel", "Saved ${filteredList.size} bookings to cache for key: $cacheKey")
+            filteredList
         }
-
-        // Save the filtered list to our cache
-        val cacheKey = cacheKeyFormatter.format(currentDate)
-        bookingsCache[cacheKey] = filtered
-        Log.d("BookingsViewModel", "Saved ${filtered.size} bookings to cache for key: $cacheKey")
 
         _bookingsForSelectedDate.postValue(filtered)
         _isLoading.postValue(false)
     }
 
+    private suspend fun loadFromCache() {
+        // Use IO dispatcher for consistency in background work
+        val cachedBookings = withContext(Dispatchers.IO) {
+            val currentDate = _selectedDate.value ?: return@withContext null
+            val cacheKey = cacheKeyFormatter.format(currentDate)
+            bookingsCache[cacheKey]
+        }
 
-    private fun loadFromCache() {
-        val currentDate = _selectedDate.value ?: return
-        val cacheKey = cacheKeyFormatter.format(currentDate)
-
-        // cachedBookings is of type List<Booking>? (nullable)
-        val cachedBookings = bookingsCache[cacheKey]
-
-        // This 'if' check is the key to solving the error
         if (cachedBookings != null) {
-            // Inside this block, Kotlin knows cachedBookings is NOT null
-            _bookingsForSelectedDate.postValue(cachedBookings) // This is now safe
-            Log.d("BookingsViewModel", "Loaded ${cachedBookings.size} bookings from cache for key: $cacheKey")
+            _bookingsForSelectedDate.postValue(cachedBookings)
+            Log.d("BookingsViewModel", "Loaded ${cachedBookings.size} bookings from cache")
         } else {
-            // If the cache returned null, we post an empty list instead
             _bookingsForSelectedDate.postValue(emptyList())
-            Log.d("BookingsViewModel", "No bookings found in cache for key: $cacheKey")
+            Log.d("BookingsViewModel", "No bookings found in cache")
         }
     }
 


### PR DESCRIPTION
This pull request enhances the `BookingsViewModel` class by adding caching for booking data, improving thread management with coroutines, and optimizing network handling. These changes aim to improve performance, user experience, and code maintainability.

### Caching Implementation:
* Introduced an `LRUCache` to store booking data for recently accessed dates, reducing redundant network calls and improving offline functionality. (`[[1]](diffhunk://#diff-f4f8cd9b7e4cf8aa092ca893340d82fa408d1b87ae327fe67ee04f22e3d79156R4-R41)`, `[[2]](diffhunk://#diff-f4f8cd9b7e4cf8aa092ca893340d82fa408d1b87ae327fe67ee04f22e3d79156L39-R187)`)
* Added a `loadFromCache` method to retrieve cached bookings when the network is unavailable, and integrated caching into the `filterBookingsForSelectedDate` method. (`[app/src/main/java/com/example/sporthub/viewmodel/BookingsViewModel.ktL39-R187](diffhunk://#diff-f4f8cd9b7e4cf8aa092ca893340d82fa408d1b87ae327fe67ee04f22e3d79156L39-R187)`)

### Coroutine and Thread Management:
* Replaced synchronous operations with coroutines using `viewModelScope` and `Dispatchers.IO` for background tasks like SharedPreferences access, data filtering, and parsing, ensuring a responsive UI. (`[[1]](diffhunk://#diff-f4f8cd9b7e4cf8aa092ca893340d82fa408d1b87ae327fe67ee04f22e3d79156R4-R41)`, `[[2]](diffhunk://#diff-f4f8cd9b7e4cf8aa092ca893340d82fa408d1b87ae327fe67ee04f22e3d79156L39-R187)`)
* Updated the `listenForUserBookings` method to handle data parsing off the main thread and to use coroutines for error handling and network checks. (`[app/src/main/java/com/example/sporthub/viewmodel/BookingsViewModel.ktL39-R187](diffhunk://#diff-f4f8cd9b7e4cf8aa092ca893340d82fa408d1b87ae327fe67ee04f22e3d79156L39-R187)`)

### SharedPreferences Integration:
* Added SharedPreferences to persist the last selected date across app sessions, improving user experience by restoring the previous state. (`[[1]](diffhunk://#diff-f4f8cd9b7e4cf8aa092ca893340d82fa408d1b87ae327fe67ee04f22e3d79156R4-R41)`, `[[2]](diffhunk://#diff-f4f8cd9b7e4cf8aa092ca893340d82fa408d1b87ae327fe67ee04f22e3d79156L39-R187)`)